### PR TITLE
Bucket renormalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: pytest
   pytest-macos:
     name: Tests (MacOS)
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           architecture: 'x64'
       - name: Install requirements
         run: |
+          xcode-select --install # See https://apple.stackexchange.com/questions/254380
           pip install -r requirements.txt
           pip install pytest>=5.3
       - name: Pytest check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
           pip install pytest>=5.3
       - name: Pytest check
         run: pytest
+  pytest-macos:
+    name: Tests (MacOS)
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+      - name: Install requirements
+        run: |
+          brew install openblas
+          pip install -r requirements.txt
+          pip install pytest>=5.3
+      - name: Pytest check
+        run: pytest
   build-docs:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           architecture: 'x64'
       - name: Install requirements
         run: |
-          xcode-select --install # See https://apple.stackexchange.com/questions/254380
+          xcode-select --reset # See https://github.com/cvxgrp/scs/issues/130
           pip install -r requirements.txt
           pip install pytest>=5.3
       - name: Pytest check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,21 +50,6 @@ jobs:
           pip install pytest>=5.3
       - name: Pytest check
         run: pytest
-  pytest-macos:
-    name: Tests (MacOS)
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-          architecture: 'x64'
-      - name: Install requirements
-        run: |
-          pip install -r requirements.txt
-          pip install pytest>=5.3
-      - name: Pytest check
-        run: pytest      
   build-docs:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,22 +50,6 @@ jobs:
           pip install pytest>=5.3
       - name: Pytest check
         run: pytest
-  pytest-macos:
-    name: Tests (MacOS)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: '3.7'
-          architecture: 'x64'
-      - name: Install requirements
-        run: |
-          xcode-select --reset # See https://github.com/cvxgrp/scs/issues/130
-          pip install -r requirements.txt
-          pip install pytest>=5.3
-      - name: Pytest check
-        run: pytest
   build-docs:
     name: Build documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
           architecture: 'x64'
       - name: Install requirements
         run: |
-          brew install openblas
           pip install -r requirements.txt
           pip install pytest>=5.3
       - name: Pytest check

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,3 @@ docs/generated
 *.ipynb
 !/docs/tutorials/*.ipynb
 !/docs/examples/*.ipynb
-
-# Data
-data/*
-inferlo/datasets/data/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ docs/generated
 *.ipynb
 !/docs/tutorials/*.ipynb
 !/docs/examples/*.ipynb
+
+# Data
+data/*
+inferlo/datasets/data/*

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ Classes representing different kinds of graphical models.
 .. autosummary::
     :toctree: generated/
 
+    inferlo.GaussianModel
     inferlo.GenericGraphModel
     inferlo.GraphModel
     inferlo.NormalFactorGraphModel
@@ -66,12 +67,11 @@ Inference algorithms
     inferlo.generic.message_passing.infer_generic_message_passing
     inferlo.generic.inference.belief_propagation
     inferlo.generic.inference.bucket_elimination
+    inferlo.generic.inference.bucket_renormalization
     inferlo.generic.inference.iterative_join_graph_propagation
-    inferlo.generic.inference.global_bucket_renormalization
     inferlo.generic.inference.mean_field
     inferlo.generic.inference.mini_bucket_elimination
-    inferlo.generic.inference.mini_bucket_renormalization
-    inferlo.generic.weighted_mini_bucket_elimination
+    inferlo.generic.inference.weighted_mini_bucket_elimination
 
 Optimization algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -155,3 +155,19 @@ Helpers to load public datasets with graphical models.
 
     inferlo.datasets.DatasetLoader
     inferlo.datasets.UaiReader
+
+Unassigned
+''''''''''''''''
+
+Following methods should be put into one of categories above
+
+.. autosummary::
+    :toctree: generated/
+
+    inferlo
+    inferlo.forney.optimization.nfg_map_lp.map_lp
+    inferlo.gaussian.inference.gaussian_belief_propagation.gaussian_BP
+    inferlo.pairwise.optimization.convex_bounds.lp_relaxation
+    inferlo.pairwise.optimization.convex_hierarchies.lasserre
+    inferlo.pairwise.optimization.convex_hierarchies.sherali_adams
+    inferlo.pairwise.optimization.map_lp.map_lp

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,6 +64,14 @@ Inference algorithms
     inferlo.forney.edge_elimination.infer_edge_elimination
     inferlo.generic.libdai_bp.BP
     inferlo.generic.message_passing.infer_generic_message_passing
+    inferlo.generic.inference.belief_propagation
+    inferlo.generic.inference.bucket_elimination
+    inferlo.generic.inference.iterative_join_graph_propagation
+    inferlo.generic.inference.global_bucket_renormalization
+    inferlo.generic.inference.mean_field
+    inferlo.generic.inference.mini_bucket_elimination
+    inferlo.generic.inference.mini_bucket_renormalization
+    inferlo.generic.weighted_mini_bucket_elimination
 
 Optimization algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -56,12 +56,6 @@ Inference algorithms
 .. autosummary::
     :toctree: generated/
 
-    inferlo.pairwise.bruteforce.infer_bruteforce
-    inferlo.pairwise.junction_tree.infer_junction_tree
-    inferlo.pairwise.inference.mean_field.infer_mean_field
-    inferlo.pairwise.inference.message_passing.infer_message_passing
-    inferlo.pairwise.inference.path_dp.infer_path_dp
-    inferlo.pairwise.inference.tree_dp.infer_tree_dp
     inferlo.forney.edge_elimination.infer_edge_elimination
     inferlo.generic.libdai_bp.BP
     inferlo.generic.message_passing.infer_generic_message_passing
@@ -72,6 +66,13 @@ Inference algorithms
     inferlo.generic.inference.mean_field
     inferlo.generic.inference.mini_bucket_elimination
     inferlo.generic.inference.weighted_mini_bucket_elimination
+    inferlo.gaussian.inference.gaussian_belief_propagation.gaussian_BP
+    inferlo.pairwise.bruteforce.infer_bruteforce
+    inferlo.pairwise.junction_tree.infer_junction_tree
+    inferlo.pairwise.inference.mean_field.infer_mean_field
+    inferlo.pairwise.inference.message_passing.infer_message_passing
+    inferlo.pairwise.inference.path_dp.infer_path_dp
+    inferlo.pairwise.inference.tree_dp.infer_tree_dp
 
 Optimization algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,10 +80,15 @@ Optimization algorithms
 .. autosummary::
     :toctree: generated/
 
+    inferlo.forney.optimization.nfg_map_lp.map_lp
     inferlo.pairwise.bruteforce.max_lh_bruteforce
     inferlo.pairwise.junction_tree.max_likelihood_junction_tree
-    inferlo.pairwise.optimization.tree_dp.max_likelihood_tree_dp
+    inferlo.pairwise.optimization.convex_bounds.lp_relaxation
+    inferlo.pairwise.optimization.convex_hierarchies.lasserre
+    inferlo.pairwise.optimization.convex_hierarchies.sherali_adams
+    inferlo.pairwise.optimization.map_lp.map_lp
     inferlo.pairwise.optimization.path_dp.max_lh_path_dp
+    inferlo.pairwise.optimization.tree_dp.max_likelihood_tree_dp
 
 Sampling algorithms
 ^^^^^^^^^^^^^^^^^^^
@@ -155,19 +161,3 @@ Helpers to load public datasets with graphical models.
 
     inferlo.datasets.DatasetLoader
     inferlo.datasets.UaiReader
-
-Misc
-''''''''''''''''
-
-Following methods should be put into one of categories above
-
-.. autosummary::
-    :toctree: generated/
-
-    inferlo
-    inferlo.forney.optimization.nfg_map_lp.map_lp
-    inferlo.gaussian.inference.gaussian_belief_propagation.gaussian_BP
-    inferlo.pairwise.optimization.convex_bounds.lp_relaxation
-    inferlo.pairwise.optimization.convex_hierarchies.lasserre
-    inferlo.pairwise.optimization.convex_hierarchies.sherali_adams
-    inferlo.pairwise.optimization.map_lp.map_lp

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -144,3 +144,14 @@ These classes are repossible for interoperation with other GM libraries.
     :toctree: generated/
 
     inferlo.interop.LibDaiInterop
+
+Datasets
+''''''''''''''''
+
+Helpers to load public datasets with graphical models.
+
+.. autosummary::
+    :toctree: generated/
+
+    inferlo.datasets.DatasetLoader
+    inferlo.datasets.UaiReader

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -156,7 +156,7 @@ Helpers to load public datasets with graphical models.
     inferlo.datasets.DatasetLoader
     inferlo.datasets.UaiReader
 
-Unassigned
+Misc
 ''''''''''''''''
 
 Following methods should be put into one of categories above

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,10 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints',
+    'generated/inferlo.rst'  # No need in page for root __init__.py.
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -124,7 +124,7 @@ Please follow [Google Python Style Guide](https://google.github.io/styleguide/py
 
 We use [sphinx](https://www.sphinx-doc.org/en/master/) to automatically 
 build the documentation. Documentation is authomatically exported to 
-ReadTheDocs.
+[ReadTheDocs](https://inferlo.readthedocs.io/).
 
 In particular, pydocs are automatically converted to "API reference" section in
 documentation. If you are adding new public class or function to the library,

--- a/inferlo/__init__.py
+++ b/inferlo/__init__.py
@@ -12,4 +12,5 @@ from .base import (
     Variable,
 )
 from .forney import NormalFactorGraphModel
+from .gaussian import GaussianModel
 from .pairwise import PairWiseFiniteModel

--- a/inferlo/base/factors/discrete_factor.py
+++ b/inferlo/base/factors/discrete_factor.py
@@ -65,6 +65,21 @@ class DiscreteFactor(Factor):
         new_factor.name = factor.get_name()
         return new_factor
 
+    @staticmethod
+    def from_flat_values(model: GraphModel,
+                         var_idx: List[int],
+                         values_flat: np.ndarray):
+        """Creates factor specified by list of values.
+
+        :param model: GM to which this factor belongs.
+        :param var_idx: Indices of variables.
+        :param values_flat: 1D list of values.
+          Last variable is "least significant".
+        """
+        shape = [model[i].domain.size() for i in var_idx]
+        values = values_flat.reshape(shape)
+        return DiscreteFactor(model, var_idx, values)
+
     def marginal(self, new_var_idx: List[int]) -> DiscreteFactor:
         """Marginalizes factor on subset of variables."""
         assert len(self.var_idx) <= 26

--- a/inferlo/datasets/__init__.py
+++ b/inferlo/datasets/__init__.py
@@ -1,1 +1,1 @@
-from .dataset_loader import promedus, linkage, load_uai_dataset
+from .dataset_loader import DatasetLoader, UaiReader

--- a/inferlo/datasets/__init__.py
+++ b/inferlo/datasets/__init__.py
@@ -1,0 +1,1 @@
+from .dataset_loader import promedus, linkage, load_uai_dataset

--- a/inferlo/datasets/dataset_loader.py
+++ b/inferlo/datasets/dataset_loader.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0.
 import os
 from dataclasses import dataclass
+import tempfile
 
 import numpy as np
 import wget
@@ -75,8 +76,13 @@ class DatasetLoader:
     """Loads graphical models from named datasets."""
 
     def __init__(self, data_dir=None):
+        """
+        :param data_dir: Where to store cached datasets. Specify if you want
+          datasets being cached locally. If not set, default system temporary
+          directory will be used.
+        """
         if data_dir is None:
-            data_dir = os.path.join(os.getcwd(), 'data')
+            data_dir = os.path.join(tempfile.gettempdir(), 'inferlo_data')
         self.data_dir = data_dir
         if not os.path.exists(self.data_dir):
             os.mkdir(self.data_dir)

--- a/inferlo/datasets/dataset_loader.py
+++ b/inferlo/datasets/dataset_loader.py
@@ -94,8 +94,18 @@ class DatasetLoader:
             assert os.path.exists(path)
         return path
 
-    def load_uai_dataset(self, dataset_name):
-        """Loads named dataset from UAI competition."""
+    def load_uai_dataset(self, dataset_name) -> Dataset:
+        """Loads named dataset from UAI competition.
+
+        :param dataset_name: Name of dataset, e.g. "Promedus_11.uai". For full
+            list of UAI datasets, see http://sli.ics.uci.edu/~ihler/uai-data/.
+            Not all of them are currently supported.
+        :return: `Dataset` object, containing graphical model
+            (as `GenericGraphModel` object), true logarithm of the partition
+            function and true marginals.
+        """
+        if dataset_name not in UAI_PF:
+            raise ValueError("Unknown UAI dataset: " + dataset_name)
         data_file = self.load_file_(UAI_PROB_URL, dataset_name)
         model = self.uai_reader.read_model(data_file)
 
@@ -105,18 +115,3 @@ class DatasetLoader:
         return Dataset(model=model,
                        true_marginals=marginals,
                        true_log_pf=UAI_PF[dataset_name] * np.log(10))
-
-def load_uai_dataset(dataset_name):
-    return DatasetLoader().load_uai_dataset(dataset_name)
-
-def promedus(dataset_id) -> Dataset:
-    """Loads UAI "Promedus" datatset with given ID."""
-    assert dataset_id >= 11 and dataset_id <= 38, "Invalid dataset ID"
-    return load_uai_dataset('Promedus_%d.uai' % dataset_id)
-
-
-def linkage(dataset_id) -> Dataset:
-    """Loads UAI "Linkage" datatset with given ID."""
-    assert dataset_id >= 11 and dataset_id <= 27, "Invalid dataset ID"
-    return load_uai_dataset('linkage_%d.uai' % dataset_id)
-

--- a/inferlo/datasets/dataset_loader.py
+++ b/inferlo/datasets/dataset_loader.py
@@ -1,0 +1,122 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+from dataclasses import dataclass
+
+from inferlo import GraphModel, GenericGraphModel
+import numpy as np
+import os
+import wget
+
+from inferlo.datasets.uai_reader import UaiReader
+
+UAI_PROB_URL = 'https://raw.githubusercontent.com/akxlr/tbp/master/tests/uai/MAR_prob'
+UAI_SOL_URL = 'https://raw.githubusercontent.com/akxlr/tbp/master/tests/uai/MAR_sol'
+
+# Copied from http://sli.ics.uci.edu/~ihler/uai-data/
+# Values here are log10.
+# TODO: load data from remote data repository.
+UAI_PF = {
+    'DBN_11.uai': 58.5307,
+    'Promedus_11.uai': -8.39145,
+    'Promedus_12.uai': -3.16462,
+    'Promedus_13.uai': -4.50703,
+    'Promedus_14.uai': -7.80675,
+    'Promedus_15.uai': -3.63667,
+    'Promedus_16.uai': -6.97522,
+    'Promedus_17.uai': -9.4592,
+    'Promedus_18.uai': -4.67228,
+    'Promedus_19.uai': -4.34464,
+    'Promedus_20.uai': -7.06065,
+    'Promedus_21.uai': -5.58012,
+    'Promedus_22.uai': -2.49474,
+    'Promedus_23.uai': -11.3151,
+    'Promedus_24.uai': -5.86181,
+    'Promedus_25.uai': -9.41791,
+    'Promedus_26.uai': -7.30489,
+    'Promedus_27.uai': -8.13576,
+    'Promedus_28.uai': -8.13152,
+    'Promedus_29.uai': -10.4527,
+    'Promedus_30.uai': -22.1005,
+    'Promedus_31.uai': -1.79979,
+    'Promedus_32.uai': -2.20193,
+    'Promedus_33.uai': -2.80866,
+    'Promedus_34.uai': -3.07996,
+    'Promedus_35.uai': -1.74295,
+    'linkage_11.uai': -31.1776,
+    'linkage_12.uai': -69.7017,
+    'linkage_13.uai': -76.0389,
+    'linkage_14.uai': -30.7614,
+    'linkage_15.uai': -76.6058,
+    'linkage_16.uai': -38.5556,
+    'linkage_17.uai': -64.8245,
+    'linkage_18.uai': -78.5222,
+    'linkage_19.uai': -59.0249,
+    'linkage_20.uai': -64.2292,
+    'linkage_21.uai': -29.6304,
+    'linkage_22.uai': -54.2777,
+    'linkage_23.uai': -116.58,
+    'linkage_24.uai': -83.7331,
+    'linkage_25.uai': -87.8848,
+    'linkage_26.uai': -115.772,
+    'linkage_27.uai': -63.4735,
+}
+
+
+@dataclass
+class Dataset:
+    """Dataset containing GM and true answers."""
+    model: GenericGraphModel
+    true_marginals: np.array
+    true_log_pf: float
+
+
+class DatasetLoader:
+    """Loads graphical models from named datasets."""
+
+    def __init__(self, data_dir=None):
+        if data_dir is None:
+            data_dir = os.path.join(os.getcwd(), 'data')
+        self.data_dir = data_dir
+        if not os.path.exists(self.data_dir):
+            os.mkdir(self.data_dir)
+        self.uai_reader = UaiReader()
+
+    def load_file_(self, url_prefix, file_name):
+        """Loads file from the web to local file.
+
+        If local file already exists, does nothing.
+        Returns local path to loaded file.
+        """
+        path = os.path.join(self.data_dir, file_name)
+        if not os.path.exists(path):
+            url = url_prefix + '/' + file_name
+            wget.download(url, out=path)
+            assert os.path.exists(path)
+        return path
+
+    def load_uai_dataset(self, dataset_name):
+        """Loads named dataset from UAI competition."""
+        data_file = self.load_file_(UAI_PROB_URL, dataset_name)
+        model = self.uai_reader.read_model(data_file)
+
+        # True marginals.
+        mar_file = self.load_file_(UAI_SOL_URL, dataset_name + '.MAR')
+        marginals = self.uai_reader.read_marginals(mar_file)
+        return Dataset(model=model,
+                       true_marginals=marginals,
+                       true_log_pf=UAI_PF[dataset_name] * np.log(10))
+
+def load_uai_dataset(dataset_name):
+    return DatasetLoader().load_uai_dataset(dataset_name)
+
+def promedus(dataset_id) -> Dataset:
+    """Loads UAI "Promedus" datatset with given ID."""
+    assert dataset_id >= 11 and dataset_id <= 38, "Invalid dataset ID"
+    return load_uai_dataset('Promedus_%d.uai' % dataset_id)
+
+
+def linkage(dataset_id) -> Dataset:
+    """Loads UAI "Linkage" datatset with given ID."""
+    assert dataset_id >= 11 and dataset_id <= 27, "Invalid dataset ID"
+    return load_uai_dataset('linkage_%d.uai' % dataset_id)
+

--- a/inferlo/datasets/dataset_loader.py
+++ b/inferlo/datasets/dataset_loader.py
@@ -1,16 +1,17 @@
 # Copyright (c) The InferLO authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0.
+import os
 from dataclasses import dataclass
 
-from inferlo import GraphModel, GenericGraphModel
 import numpy as np
-import os
 import wget
 
+from inferlo import GenericGraphModel
 from inferlo.datasets.uai_reader import UaiReader
 
-UAI_PROB_URL = 'https://raw.githubusercontent.com/akxlr/tbp/master/tests/uai/MAR_prob'
-UAI_SOL_URL = 'https://raw.githubusercontent.com/akxlr/tbp/master/tests/uai/MAR_sol'
+REPO_URL = 'https://raw.githubusercontent.com/akxlr/tbp/master/tests/uai/'
+UAI_PROB_URL = REPO_URL + 'MAR_prob'
+UAI_SOL_URL = REPO_URL + 'MAR_sol'
 
 # Copied from http://sli.ics.uci.edu/~ihler/uai-data/
 # Values here are log10.

--- a/inferlo/datasets/dataset_loader_test.py
+++ b/inferlo/datasets/dataset_loader_test.py
@@ -1,0 +1,31 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+import numpy as np
+import inferlo
+
+
+def test_load_promedus():
+    dataset = inferlo.datasets.promedus(20)
+    assert dataset.model.num_variables == 546
+    assert len(dataset.model.factors) == 546
+    assert dataset.model.factors[2].var_idx == [80, 544]
+    assert np.allclose(dataset.model.factors[2].values,
+                       np.array([[0.97, 0], [0.03, 1]]))
+    assert len(dataset.true_marginals) == 546
+    assert np.allclose(dataset.true_marginals[0],
+                       np.array([0.998495, 0.00150482]))
+    assert np.allclose(dataset.true_log_z, -7.06065)
+
+
+def test_load_linkage():
+    dataset = inferlo.datasets.linkage(20)
+    assert dataset.model.num_variables == 1160
+    assert len(dataset.model.factors) == 1160
+    assert dataset.model.factors[1].var_idx == [5, 1]
+    assert np.allclose(dataset.model.factors[1].values,
+                       np.array([[0.9, 0.1], [0.1, 0.9]]))
+    assert len(dataset.true_marginals) == 1160
+    assert np.allclose(dataset.true_marginals[0], np.array([1, 0, 0, 0, 0]))
+    assert np.allclose(dataset.true_marginals[1],
+                       np.array([0.505242, 0.494758, 0, 0, 0]))
+    assert np.allclose(dataset.true_log_z, -64.2292)

--- a/inferlo/datasets/dataset_loader_test.py
+++ b/inferlo/datasets/dataset_loader_test.py
@@ -16,7 +16,7 @@ def test_load_promedus():
     assert len(dataset.true_marginals) == 546
     assert np.allclose(dataset.true_marginals[0],
                        np.array([0.998495, 0.00150482]))
-    assert np.allclose(dataset.true_log_pf, -7.06065)
+    assert np.allclose(dataset.true_log_pf, -16.26, atol=1e-2)
 
 
 def test_load_linkage():
@@ -30,4 +30,4 @@ def test_load_linkage():
     assert np.allclose(dataset.true_marginals[0], np.array([1, 0, 0, 0, 0]))
     assert np.allclose(dataset.true_marginals[1],
                        np.array([0.505242, 0.494758, 0, 0, 0]))
-    assert np.allclose(dataset.true_log_pf, -64.2292)
+    assert np.allclose(dataset.true_log_pf, -147.89, atol=1e-2)

--- a/inferlo/datasets/dataset_loader_test.py
+++ b/inferlo/datasets/dataset_loader_test.py
@@ -1,6 +1,7 @@
 # Copyright (c) The InferLO authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0.
 import numpy as np
+
 import inferlo
 
 dataset_loader = inferlo.datasets.DatasetLoader()

--- a/inferlo/datasets/dataset_loader_test.py
+++ b/inferlo/datasets/dataset_loader_test.py
@@ -3,9 +3,11 @@
 import numpy as np
 import inferlo
 
+dataset_loader = inferlo.datasets.DatasetLoader()
+
 
 def test_load_promedus():
-    dataset = inferlo.datasets.promedus(20)
+    dataset = dataset_loader.load_uai_dataset('Promedus_20.uai')
     assert dataset.model.num_variables == 546
     assert len(dataset.model.factors) == 546
     assert dataset.model.factors[2].var_idx == [80, 544]
@@ -14,11 +16,11 @@ def test_load_promedus():
     assert len(dataset.true_marginals) == 546
     assert np.allclose(dataset.true_marginals[0],
                        np.array([0.998495, 0.00150482]))
-    assert np.allclose(dataset.true_log_z, -7.06065)
+    assert np.allclose(dataset.true_log_pf, -7.06065)
 
 
 def test_load_linkage():
-    dataset = inferlo.datasets.linkage(20)
+    dataset = dataset_loader.load_uai_dataset('linkage_20.uai')
     assert dataset.model.num_variables == 1160
     assert len(dataset.model.factors) == 1160
     assert dataset.model.factors[1].var_idx == [5, 1]
@@ -28,4 +30,4 @@ def test_load_linkage():
     assert np.allclose(dataset.true_marginals[0], np.array([1, 0, 0, 0, 0]))
     assert np.allclose(dataset.true_marginals[1],
                        np.array([0.505242, 0.494758, 0, 0, 0]))
-    assert np.allclose(dataset.true_log_z, -64.2292)
+    assert np.allclose(dataset.true_log_pf, -64.2292)

--- a/inferlo/datasets/uai_reader.py
+++ b/inferlo/datasets/uai_reader.py
@@ -1,0 +1,83 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+from inferlo import GenericGraphModel, DiscreteDomain, DiscreteFactor
+import numpy as np
+
+
+class UaiReader():
+    """Reads GM from file in UAI format.
+
+    Format description:
+    http://www.hlt.utdallas.edu/~vgogate/uai14-competition/modelformat.html
+    """
+
+    def __init__(self):
+        self.pos = 0
+        self.tokens = []
+
+    def read_file(self, path):
+        with open(path, 'r') as file:
+            self.tokens = ''.join(file.readlines()).split()
+        self.pos = 0
+
+    def next_token(self):
+        self.pos += 1
+        return self.tokens[self.pos - 1]
+
+    def next_int(self):
+        return int(self.next_token())
+
+    def read_model(self, path) -> GenericGraphModel:
+        """Reads Graphical model form a file in UAI format.
+
+        :param path: Local path to text file with GM in UAI format.
+        """
+        # Read model type.
+        self.read_file(path)
+        model_type = self.next_token()
+        assert model_type == 'MARKOV', 'Unsupported model type: %s' % model_type
+
+        # Read variables' cardinalities and initialize the model.
+        num_vars = int(self.next_int())
+        model = GenericGraphModel(num_vars)
+        for i in range(num_vars):
+            model[i].domain = DiscreteDomain.range(int(self.next_token()))
+
+        # Read which variables are in which factors.
+        num_factors = self.next_int()
+        var_idx_list = []
+        for factor_id in range(num_factors):
+            var_count = self.next_int()
+            var_idx = [self.next_int() for _ in range(var_count)]
+            var_idx_list.append(var_idx)
+
+        # Read factors' values and add factors to the model.
+        for factor_id in range(num_factors):
+            vals_count = self.next_int()
+            vals = np.array(
+                [np.float64(self.next_token()) for _ in range(vals_count)])
+            factor = DiscreteFactor.from_flat_values(model,
+                                                     var_idx_list[factor_id],
+                                                     vals)
+            model.add_factor(factor)
+
+        return model
+
+    def read_marginals(self, path) -> np.array:
+        # Format description:
+        # http://www.hlt.utdallas.edu/~vgogate/uai14-competition/resformat.html
+        self.read_file(path)
+        assert self.next_token() == "MAR"
+
+        vars_num = self.next_int()
+        marginals = []
+        for i in range(vars_num):
+            domain_size = self.next_int()
+            marginals.append(
+                [np.float64(self.next_token()) for _ in range(domain_size)])
+        max_domain_size = max([len(x) for x in marginals])
+        ans = np.zeros((vars_num, max_domain_size))
+        for i in range(vars_num):
+            for j in range(len(marginals[i])):
+                ans[i, j] = marginals[i][j]
+        return ans

--- a/inferlo/datasets/uai_reader.py
+++ b/inferlo/datasets/uai_reader.py
@@ -1,7 +1,8 @@
 # Copyright (c) The InferLO authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0.
-from inferlo import GenericGraphModel, DiscreteDomain, DiscreteFactor
 import numpy as np
+
+from inferlo import GenericGraphModel, DiscreteDomain, DiscreteFactor
 
 
 class UaiReader():
@@ -11,17 +12,17 @@ class UaiReader():
         self.pos = 0
         self.tokens = []
 
-    def read_file_(self, path):
+    def _read_file(self, path):
         with open(path, 'r') as file:
             self.tokens = ''.join(file.readlines()).split()
         self.pos = 0
 
-    def next_token_(self):
+    def _next_token(self):
         self.pos += 1
         return self.tokens[self.pos - 1]
 
-    def next_int_(self):
-        return int(self.next_token_())
+    def _next_int(self):
+        return int(self._next_token())
 
     def read_model(self, path) -> GenericGraphModel:
         """Reads Graphical model form a file in UAI format.
@@ -33,29 +34,29 @@ class UaiReader():
         :return: Graphical model read from the file.
         """
         # Read model type.
-        self.read_file_(path)
-        model_type = self.next_token_()
+        self._read_file(path)
+        model_type = self._next_token()
         assert model_type == 'MARKOV', 'Unsupported model type: %s' % model_type
 
         # Read variables' cardinalities and initialize the model.
-        num_vars = int(self.next_int_())
+        num_vars = int(self._next_int())
         model = GenericGraphModel(num_vars)
         for i in range(num_vars):
-            model[i].domain = DiscreteDomain.range(int(self.next_token_()))
+            model[i].domain = DiscreteDomain.range(int(self._next_token()))
 
         # Read which variables are in which factors.
-        num_factors = self.next_int_()
+        num_factors = self._next_int()
         var_idx_list = []
         for factor_id in range(num_factors):
-            var_count = self.next_int_()
-            var_idx = [self.next_int_() for _ in range(var_count)]
+            var_count = self._next_int()
+            var_idx = [self._next_int() for _ in range(var_count)]
             var_idx_list.append(var_idx)
 
         # Read factors' values and add factors to the model.
         for factor_id in range(num_factors):
-            vals_count = self.next_int_()
+            vals_count = self._next_int()
             vals = np.array(
-                [np.float64(self.next_token_()) for _ in range(vals_count)])
+                [np.float64(self._next_token()) for _ in range(vals_count)])
             factor = DiscreteFactor.from_flat_values(model,
                                                      var_idx_list[factor_id],
                                                      vals)
@@ -75,15 +76,15 @@ class UaiReader():
           probability that ``i``-th variable takes ``j``-th value (or 0 if this
           variable's domain size is less than ``j+1``).
         """
-        self.read_file_(path)
-        assert self.next_token_() == "MAR"
+        self._read_file(path)
+        assert self._next_token() == "MAR"
 
-        vars_num = self.next_int_()
+        vars_num = self._next_int()
         marginals = []
         for i in range(vars_num):
-            domain_size = self.next_int_()
+            domain_size = self._next_int()
             marginals.append(
-                [np.float64(self.next_token_()) for _ in range(domain_size)])
+                [np.float64(self._next_token()) for _ in range(domain_size)])
         max_domain_size = max([len(x) for x in marginals])
         ans = np.zeros((vars_num, max_domain_size))
         for i in range(vars_num):

--- a/inferlo/datasets/uai_reader.py
+++ b/inferlo/datasets/uai_reader.py
@@ -5,57 +5,57 @@ import numpy as np
 
 
 class UaiReader():
-    """Reads GM from file in UAI format.
-
-    Format description:
-    http://www.hlt.utdallas.edu/~vgogate/uai14-competition/modelformat.html
-    """
+    """Reads files in UAI format."""
 
     def __init__(self):
         self.pos = 0
         self.tokens = []
 
-    def read_file(self, path):
+    def read_file_(self, path):
         with open(path, 'r') as file:
             self.tokens = ''.join(file.readlines()).split()
         self.pos = 0
 
-    def next_token(self):
+    def next_token_(self):
         self.pos += 1
         return self.tokens[self.pos - 1]
 
-    def next_int(self):
-        return int(self.next_token())
+    def next_int_(self):
+        return int(self.next_token_())
 
     def read_model(self, path) -> GenericGraphModel:
         """Reads Graphical model form a file in UAI format.
 
+        Format description:
+        http://www.hlt.utdallas.edu/~vgogate/uai14-competition/modelformat.html
+
         :param path: Local path to text file with GM in UAI format.
+        :return: Graphical model read from the file.
         """
         # Read model type.
-        self.read_file(path)
-        model_type = self.next_token()
+        self.read_file_(path)
+        model_type = self.next_token_()
         assert model_type == 'MARKOV', 'Unsupported model type: %s' % model_type
 
         # Read variables' cardinalities and initialize the model.
-        num_vars = int(self.next_int())
+        num_vars = int(self.next_int_())
         model = GenericGraphModel(num_vars)
         for i in range(num_vars):
-            model[i].domain = DiscreteDomain.range(int(self.next_token()))
+            model[i].domain = DiscreteDomain.range(int(self.next_token_()))
 
         # Read which variables are in which factors.
-        num_factors = self.next_int()
+        num_factors = self.next_int_()
         var_idx_list = []
         for factor_id in range(num_factors):
-            var_count = self.next_int()
-            var_idx = [self.next_int() for _ in range(var_count)]
+            var_count = self.next_int_()
+            var_idx = [self.next_int_() for _ in range(var_count)]
             var_idx_list.append(var_idx)
 
         # Read factors' values and add factors to the model.
         for factor_id in range(num_factors):
-            vals_count = self.next_int()
+            vals_count = self.next_int_()
             vals = np.array(
-                [np.float64(self.next_token()) for _ in range(vals_count)])
+                [np.float64(self.next_token_()) for _ in range(vals_count)])
             factor = DiscreteFactor.from_flat_values(model,
                                                      var_idx_list[factor_id],
                                                      vals)
@@ -64,17 +64,26 @@ class UaiReader():
         return model
 
     def read_marginals(self, path) -> np.array:
-        # Format description:
-        # http://www.hlt.utdallas.edu/~vgogate/uai14-competition/resformat.html
-        self.read_file(path)
-        assert self.next_token() == "MAR"
+        """Reads true marginals form a file in UAI format.
 
-        vars_num = self.next_int()
+        Format description:
+        http://www.hlt.utdallas.edu/~vgogate/uai14-competition/resformat.html
+
+        :param path: Local path to text file with true marginals in UAI format.
+        :return: 2D numpy array. First dimension is number of variables,
+          second is maximal domain size of a variable. ``result[i][j]`` is a
+          probability that ``i``-th variable takes ``j``-th value (or 0 if this
+          variable's domain size is less than ``j+1``).
+        """
+        self.read_file_(path)
+        assert self.next_token_() == "MAR"
+
+        vars_num = self.next_int_()
         marginals = []
         for i in range(vars_num):
-            domain_size = self.next_int()
+            domain_size = self.next_int_()
             marginals.append(
-                [np.float64(self.next_token()) for _ in range(domain_size)])
+                [np.float64(self.next_token_()) for _ in range(domain_size)])
         max_domain_size = max([len(x) for x in marginals])
         ans = np.zeros((vars_num, max_domain_size))
         for i in range(vars_num):

--- a/inferlo/forney/edge_elimination.py
+++ b/inferlo/forney/edge_elimination.py
@@ -92,7 +92,7 @@ def infer_edge_elimination(model: NormalFactorGraphModel):
     # Don't reference model from this point to ensure we don't modify it.
 
     num_edges = len(edges)
-    edge_exists = np.ones(num_edges, dtype=np.bool)
+    edge_exists = np.ones(num_edges, dtype=bool)
 
     # Heuristic to find which edge to eliminate. Will pick edge of least cost.
     def edge_cost(edge_id):

--- a/inferlo/forney/optimization/nfg_map_lp.py
+++ b/inferlo/forney/optimization/nfg_map_lp.py
@@ -16,51 +16,53 @@ map_lp_result = namedtuple('map_lp_result', ['upper_bound',
 
 
 def map_lp(model: NormalFactorGraphModel) -> map_lp_result:
-    """
-        This function implements linear programming (LP) relaxation
-        of maximum a posteriori assignment problem (MAP) for
-        normal factor graph with finite alphabet.
+    """LP relaxation of MAP for NFG model.
 
-        The goal of MAP estimation is to find most probable
-        assignment of original variables by maximizing probability
-        density function. For the case of pairwise finite model it
-        reduces to maximization of polynomial over finite
-        field.
+    This function implements linear programming (LP) relaxation
+    of maximum a posteriori assignment problem (MAP) for
+    normal factor graph with finite alphabet.
 
-        For every variable, we introduce Q non-negative belief variables
-        where Q is the size of the alphabet. Every such variable
-        is our 'belief' that variable at node takes particular value.
+    The goal of MAP estimation is to find most probable
+    assignment of original variables by maximizing probability
+    density function. For the case of pairwise finite model it
+    reduces to maximization of polynomial over finite
+    field.
 
-        Analogously, for every factor we introduce Q^deg beliefs
-        where deg is a number of variables in factor.
+    For every variable, we introduce Q non-negative belief variables
+    where Q is the size of the alphabet. Every such variable
+    is our 'belief' that variable at node takes particular value.
 
-        For both node and edge beliefs we require normalization
-        constraints: 1) for every variable, the sum of beliefs
-        equals one and 2) for every factor the sum of beliefs
-        equals one.
+    Analogously, for every factor we introduce Q^deg beliefs
+    where deg is a number of variables in factor.
 
-        We also add marginalization constraint: for every factor,
-        summing factor beliefs over all except one node must equal
-        to the node belief at that node.
+    For both node and edge beliefs we require normalization
+    constraints: 1) for every variable, the sum of beliefs
+    equals one and 2) for every factor the sum of beliefs
+    equals one.
 
-        Finally we get a linear program and its solution is an
-        upper bound on the MAP value. We restore the lower bound
-        on MAP value as the solution of the dual relaxation.
+    We also add marginalization constraint: for every factor,
+    summing factor beliefs over all except one node must equal
+    to the node belief at that node.
 
-        More details may be found in "MAP Estimation,
-        Linear Programming and BeliefPropagation with
-        Convex Free Energies" by Yair Weiss, Chen Yanover and Talya
-        Meltzer. https://arxiv.org/pdf/1206.5286.pdf
+    Finally we get a linear program and its solution is an
+    upper bound on the MAP value. We restore the lower bound
+    on MAP value as the solution of the dual relaxation.
 
-        The output of the function is:
-        1) upper bound on MAP value (solution of LP)
-        2) lower bound on MAP value (dual solution)
-        3) Optimal values of factor beliefs
-        4) Optimal values of variable beliefs
-        5) Optimal values of dual variables that correspond to
-          normalization constraints
-        6) Optimal values of dual variables that correspond to
-          marginalization constraints
+    More details may be found in "MAP Estimation,
+    Linear Programming and BeliefPropagation with
+    Convex Free Energies" by Yair Weiss, Chen Yanover and Talya
+    Meltzer. https://arxiv.org/pdf/1206.5286.pdf
+
+    The output of the function is:
+
+    1. upper bound on MAP value (solution of LP);
+    2. lower bound on MAP value (dual solution);
+    3. Optimal values of factor beliefs;
+    4. Optimal values of variable beliefs;
+    5. Optimal values of dual variables that correspond to normalization
+       constraints;
+    6. Optimal values of dual variables that correspond to marginalization
+       constraints.
     """
 
     al_size = model._default_domain.size()

--- a/inferlo/forney/optimization/nfg_map_lp.py
+++ b/inferlo/forney/optimization/nfg_map_lp.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from collections import namedtuple
 from itertools import product
 import cvxpy as cp

--- a/inferlo/forney/optimization/nfg_map_lp_test.py
+++ b/inferlo/forney/optimization/nfg_map_lp_test.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
 
 from inferlo.testing import grid_potts_model

--- a/inferlo/gaussian/gaussian_model.py
+++ b/inferlo/gaussian/gaussian_model.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from __future__ import annotations
 from functools import partial
 from collections import defaultdict

--- a/inferlo/gaussian/gaussian_model_test.py
+++ b/inferlo/gaussian/gaussian_model_test.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
 from inferlo.gaussian import GaussianModel
 

--- a/inferlo/gaussian/inference/gaussian_belief_propagation.py
+++ b/inferlo/gaussian/inference/gaussian_belief_propagation.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
 
 

--- a/inferlo/generic/inference/__init__.py
+++ b/inferlo/generic/inference/__init__.py
@@ -7,7 +7,7 @@ from .inference import (belief_propagation,
                         weighted_mini_bucket_elimination)
 
 """
-Some code in this directory was copied from 
-https://github.com/sungsoo-ahn/bucket-renormalization 
-(licenced under MIT license). 
+Some code in this directory was copied from
+https://github.com/sungsoo-ahn/bucket-renormalization
+(licenced under MIT license).
 """

--- a/inferlo/generic/inference/__init__.py
+++ b/inferlo/generic/inference/__init__.py
@@ -1,13 +1,14 @@
-from .belief_propagation import  BeliefPropagation, IterativeJoinGraphPropagation
-from .bucket_elimination import BucketElimination
-from .bucket_renormalization import BucketRenormalization
-from .mean_field import MeanField
-from .mini_bucket_elimination import MiniBucketElimination
-from .weighted_mini_bucket_elimination import WeightedMiniBucketElimination
+from .inference import (belief_propagation,
+                        bucket_elimination,
+                        iterative_join_graph_propagation,
+                        global_bucket_renormalization,
+                        mean_field,
+                        mini_bucket_elimination,
+                        mini_bucket_renormalization,
+                        weighted_mini_bucket_elimination)
 
 """
 Some code in this directory was copied from 
 https://github.com/sungsoo-ahn/bucket-renormalization 
 (licenced under MIT license). 
 """
-

--- a/inferlo/generic/inference/__init__.py
+++ b/inferlo/generic/inference/__init__.py
@@ -1,8 +1,13 @@
 from .belief_propagation import  BeliefPropagation, IterativeJoinGraphPropagation
 from .bucket_elimination import BucketElimination
 from .bucket_renormalization import BucketRenormalization
-from .factor import Factor
-from .graphical_model import GraphicalModel, from_inferlo_model
 from .mean_field import MeanField
 from .mini_bucket_elimination import MiniBucketElimination
 from .weighted_mini_bucket_elimination import WeightedMiniBucketElimination
+
+"""
+Some code in this directory was copied from 
+https://github.com/sungsoo-ahn/bucket-renormalization 
+(licenced under MIT license). 
+"""
+

--- a/inferlo/generic/inference/__init__.py
+++ b/inferlo/generic/inference/__init__.py
@@ -1,10 +1,9 @@
 from .inference import (belief_propagation,
                         bucket_elimination,
+                        bucket_renormalization,
                         iterative_join_graph_propagation,
-                        global_bucket_renormalization,
                         mean_field,
                         mini_bucket_elimination,
-                        mini_bucket_renormalization,
                         weighted_mini_bucket_elimination)
 
 """

--- a/inferlo/generic/inference/__init__.py
+++ b/inferlo/generic/inference/__init__.py
@@ -1,0 +1,8 @@
+from .belief_propagation import  BeliefPropagation, IterativeJoinGraphPropagation
+from .bucket_elimination import BucketElimination
+from .bucket_renormalization import BucketRenormalization
+from .factor import Factor
+from .graphical_model import GraphicalModel, from_inferlo_model
+from .mean_field import MeanField
+from .mini_bucket_elimination import MiniBucketElimination
+from .weighted_mini_bucket_elimination import WeightedMiniBucketElimination

--- a/inferlo/generic/inference/belief_propagation.py
+++ b/inferlo/generic/inference/belief_propagation.py
@@ -1,12 +1,8 @@
 import numpy as np
 from copy import copy
-from functools import reduce
-import sys
 
-sys.path.extend(["graphical_model/"])
-from factor import Factor, product_over_, entropy
+from inferlo.generic.inference.factor import Factor, product_over_, entropy
 import random
-import time
 
 
 def default_message_name(prefix="_M"):

--- a/inferlo/generic/inference/belief_propagation.py
+++ b/inferlo/generic/inference/belief_propagation.py
@@ -1,0 +1,166 @@
+import numpy as np
+from copy import copy
+from functools import reduce
+import sys
+
+sys.path.extend(["graphical_model/"])
+from factor import Factor, product_over_, entropy
+import random
+import time
+
+
+def default_message_name(prefix="_M"):
+    default_message_name.cnt += 1
+    return prefix + str(default_message_name.cnt)
+
+
+default_message_name.cnt = 0
+
+
+class BeliefPropagation:
+    def __init__(self, model):
+        self.model = model.copy()
+        init_np_func = np.ones
+        self.factors_adj_to_ = {
+            var: self.model.get_adj_factors(var) for var in self.model.variables
+        }
+
+        self.messages = dict()
+        for fac in model.factors:
+            for var in fac.variables:
+                self.messages[(fac, var)] = Factor.initialize_with_(
+                    default_message_name(), [var], init_np_func, model.get_cardinality_for_(var)
+                )
+                self.messages[(fac, var)].normalize()
+
+        for fac in model.factors:
+            for var in fac.variables:
+                self.messages[(var, fac)] = Factor.initialize_with_(
+                    default_message_name(), [var], init_np_func, model.get_cardinality_for_(var)
+                )
+                self.messages[(var, fac)].normalize()
+
+    def run(self, max_iter=1000, converge_thr=1e-5, damp_ratio=0.1):
+        for t in range(max_iter):
+            old_messages = {key: item.copy() for key, item in self.messages.items()}
+            self._update_messages(damp_ratio)
+            if self._is_converged(converge_thr, self.messages, old_messages):
+                break
+
+        self.beliefs = {}
+        for var in self.model.variables:
+            self.beliefs[var] = product_over_(*self._message_to_(var)).normalize(inplace=False)
+
+        for fac in self.model.factors:
+            self.beliefs[fac] = product_over_(fac, *self._message_to_(fac)).normalize(inplace=False)
+
+        logZ = self.get_logZ()
+        return logZ
+
+    def get_logZ(self):
+        logZ = 0.0
+        for var in self.model.variables:
+            logZ += (1 - self.model.degree(var)) * entropy(self.beliefs[var])
+
+        for fac in self.model.factors:
+            logZ += entropy(self.beliefs[fac], fac)
+
+        return logZ
+
+    def _update_messages(self, damp_ratio):
+        temp_messages = dict()
+        factor_order = copy(self.model.factors)
+        random.shuffle(factor_order)
+        for fac in factor_order:
+            for var in fac.variables:
+                next_message = (
+                    product_over_(fac, *[msg for msg in self._message_to_(fac, except_objs=[var])])
+                    .marginalize_except_([var], inplace=False)
+                    .normalize(inplace=False)
+                )
+                self.messages[(fac, var)] = (
+                    damp_ratio * self.messages[(fac, var)] + (1 - damp_ratio) * next_message
+                )
+
+        variable_order = copy(self.model.variables)
+        random.shuffle(variable_order)
+        for var in variable_order:
+            for fac in self.factors_adj_to_[var]:
+                messages_to_var_except_fac = self._message_to_(var, except_objs=[fac])
+                if messages_to_var_except_fac:
+                    next_message = product_over_(*messages_to_var_except_fac).normalize(
+                        inplace=False
+                    )
+                    self.messages[(var, fac)] = (
+                        damp_ratio * self.messages[(var, fac)] + (1 - damp_ratio) * next_message
+                    )
+
+    def _is_converged(self, converge_thr, messages, new_messages):
+        for var in self.model.variables:
+            blf = product_over_(
+                *[messages[(fac, var)] for fac in self.factors_adj_to_[var]]
+            ).normalize(inplace=False)
+            new_blf = product_over_(
+                *[new_messages[(fac, var)] for fac in self.factors_adj_to_[var]]
+            ).normalize(inplace=False)
+            if np.sum(np.abs(blf.values - new_blf.values)) > converge_thr:
+                return False
+
+        return True
+
+    def _message_to_(self, obj, except_objs=[]):
+        if obj in self.model.factors:
+            return [self.messages[(var, obj)] for var in obj.variables if var not in except_objs]
+        elif obj in self.model.variables:
+            return [
+                self.messages[(fac, obj)]
+                for fac in self.factors_adj_to_[obj]
+                if fac not in except_objs
+            ]
+        else:
+            raise TypeError("Object {obj} not in the model.".format(obj=obj))
+
+
+class IterativeJoinGraphPropagation(BeliefPropagation):
+    def __init__(self, model, ibound):
+        self.org_model = model.copy()
+        model = model.copy()
+
+        unelminated_variables = copy(model.variables)
+        while unelminated_variables:
+
+            def get_bucket_size(facs):
+                adj_adj_vars = [fac.variables for fac in facs]
+                a = set()
+                for vars in adj_adj_vars:
+                    a = a.union(vars)
+                return len(a)
+
+            get_key = lambda var: get_bucket_size(model.get_adj_factors(var))
+
+            var = min(unelminated_variables, key=get_key)
+            unelminated_variables.pop(unelminated_variables.index(var))
+            if get_key(var) == 1:
+                pass
+            elif get_key(var) < ibound:
+                model.contract_variable(var)
+            else:
+                facs = model.get_adj_factors(var)
+                model.remove_factors_from(facs)
+                mini_buckets = []
+                for fac in facs:
+                    mini_bucket = next(
+                        (mb for mb in mini_buckets if get_bucket_size(mb + [fac]) < ibound), False
+                    )
+                    if mini_bucket:
+                        mini_bucket.append(fac)
+                    else:
+                        mini_buckets.append([fac])
+
+                for mini_bucket in mini_buckets:
+                    if mini_bucket:
+                        model.add_factor(product_over_(*mini_bucket))
+                    else:
+                        print("empty mini-bucket")
+
+        super(IterativeJoinGraphPropagation, self).__init__(model)

--- a/inferlo/generic/inference/belief_propagation.py
+++ b/inferlo/generic/inference/belief_propagation.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import random
 from copy import copy
 

--- a/inferlo/generic/inference/belief_propagation.py
+++ b/inferlo/generic/inference/belief_propagation.py
@@ -1,9 +1,7 @@
 import numpy as np
 from copy import copy
 
-from inferlo import GraphModel
 from .factor import Factor, product_over_, entropy
-from .graphical_model import GraphicalModel
 import random
 
 
@@ -71,7 +69,6 @@ class BeliefPropagation:
         return logZ
 
     def _update_messages(self, damp_ratio):
-        temp_messages = dict()
         factor_order = copy(self.model.factors)
         random.shuffle(factor_order)
         for fac in factor_order:
@@ -131,10 +128,6 @@ class BeliefPropagation:
         else:
             raise TypeError("Object {obj} not in the model.".format(obj=obj))
 
-    @staticmethod
-    def create(model: GraphModel) -> 'BeliefPropagation':
-        return BeliefPropagation(GraphicalModel.from_inferlo_model(model))
-
 
 class IterativeJoinGraphPropagation(BeliefPropagation):
     def __init__(self, model, ibound):
@@ -180,9 +173,3 @@ class IterativeJoinGraphPropagation(BeliefPropagation):
                         print("empty mini-bucket")
 
         super(IterativeJoinGraphPropagation, self).__init__(model)
-
-    @staticmethod
-    def create(model: GraphModel,
-               ibound: int) -> 'IterativeJoinGraphPropagation':
-        return IterativeJoinGraphPropagation(
-            GraphicalModel.from_inferlo_model(model), ibound)

--- a/inferlo/generic/inference/bucket_elimination.py
+++ b/inferlo/generic/inference/bucket_elimination.py
@@ -2,17 +2,19 @@
 # Licensed under the Apache License, Version 2.0 - see LICENSE.
 import random
 from copy import copy
+from typing import List
 
-from inferlo.base.graph_model import GraphModel
 from .factor import Factor, product_over_
-from .graphical_model import GraphicalModel
 
 
 class BucketElimination:
+    """Bucket elimination algorithm."""
+
     def __init__(self, model):
         self.model = model.copy()
 
-    def run(self, elimination_order_method="random", **kwargs):
+    def run(self, elimination_order_method="random", **kwargs) -> float:
+        """Runs the algorithm, returns log(Z)."""
         if elimination_order_method == "random":
             elimination_order = copy(self.model.variables)
             random.shuffle(elimination_order)
@@ -35,7 +37,10 @@ class BucketElimination:
 
         return Z.log_values
 
-    def get_marginal_factor(self, elimination_order_method="random", **kwargs):
+    def get_marginal_factor(self,
+                            elimination_order_method="random",
+                            **kwargs) -> Factor:
+        """Returns marginal factor."""
         if elimination_order_method == "random":
             elimination_order = copy(self.model.variables)
             random.shuffle(elimination_order)
@@ -53,11 +58,8 @@ class BucketElimination:
         max_ibound = 0
         for var in elimination_order:
             if var not in exception_variables:
-                max_ibound = max(
-                    max_ibound,
-                    get_bucket_size(
-                        [fac for fac in eliminated_model.get_adj_factors(var)]),
-                )
+                max_ibound = max(max_ibound, get_bucket_size(
+                    [fac for fac in eliminated_model.get_adj_factors(var)]), )
                 eliminated_model.contract_variable(var)
 
         final_factor = product_over_(*eliminated_model.factors)
@@ -67,9 +69,9 @@ class BucketElimination:
         return final_factor
 
 
-def get_bucket_size(bucket):
+def get_bucket_size(bucket: List[Factor]):
+    """Counts variables referenced by factors in a bucket."""
     s = set()
     for fac in bucket:
         s = s.union(set(fac.variables))
-
     return len(s)

--- a/inferlo/generic/inference/bucket_elimination.py
+++ b/inferlo/generic/inference/bucket_elimination.py
@@ -66,10 +66,6 @@ class BucketElimination:
 
         return final_factor
 
-    @staticmethod
-    def create(model: GraphModel) -> 'BucketElimination':
-        return BucketElimination(GraphicalModel.from_inferlo_model(model))
-
 
 def get_bucket_size(bucket):
     s = set()

--- a/inferlo/generic/inference/bucket_elimination.py
+++ b/inferlo/generic/inference/bucket_elimination.py
@@ -1,7 +1,11 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import random
 from copy import copy
 
-from inferlo.generic.inference.factor  import Factor, product_over_
+from inferlo.base.graph_model import GraphModel
+from .factor import Factor, product_over_
+from .graphical_model import GraphicalModel
 
 
 class BucketElimination:
@@ -21,7 +25,8 @@ class BucketElimination:
         max_ibound = 0
         for var in elimination_order:
             max_ibound = max(
-                max_ibound, get_bucket_size([fac for fac in eliminated_model.get_adj_factors(var)])
+                max_ibound, get_bucket_size(
+                    [fac for fac in eliminated_model.get_adj_factors(var)])
             )
             eliminated_model.contract_variable(var)
         Z = Factor.scalar(1.0)
@@ -50,7 +55,8 @@ class BucketElimination:
             if var not in exception_variables:
                 max_ibound = max(
                     max_ibound,
-                    get_bucket_size([fac for fac in eliminated_model.get_adj_factors(var)]),
+                    get_bucket_size(
+                        [fac for fac in eliminated_model.get_adj_factors(var)]),
                 )
                 eliminated_model.contract_variable(var)
 
@@ -59,6 +65,10 @@ class BucketElimination:
             final_factor.transpose_by_(exception_variables)
 
         return final_factor
+
+    @staticmethod
+    def create(model: GraphModel) -> 'BucketElimination':
+        return BucketElimination(GraphicalModel.from_inferlo_model(model))
 
 
 def get_bucket_size(bucket):

--- a/inferlo/generic/inference/bucket_elimination.py
+++ b/inferlo/generic/inference/bucket_elimination.py
@@ -1,0 +1,73 @@
+import sys
+import numpy as np
+import random
+from functools import reduce
+from copy import copy
+
+sys.path.extend(["graphical_model/"])
+from factor import Factor, product_over_
+
+
+class BucketElimination:
+    def __init__(self, model):
+        self.model = model.copy()
+
+    def run(self, elimination_order_method="random", **kwargs):
+        if elimination_order_method == "random":
+            elimination_order = copy(self.model.variables)
+            random.shuffle(elimination_order)
+        elif elimination_order_method == "not_random":
+            elimination_order = copy(self.model.variables)
+        elif elimination_order_method == "given":
+            elimination_order = kwargs["elimination_order"]
+
+        eliminated_model = self.model.copy()
+        max_ibound = 0
+        for var in elimination_order:
+            max_ibound = max(
+                max_ibound, get_bucket_size([fac for fac in eliminated_model.get_adj_factors(var)])
+            )
+            eliminated_model.contract_variable(var)
+        Z = Factor.scalar(1.0)
+        for fac in eliminated_model.factors:
+            Z = Z * fac
+
+        return Z.log_values
+
+    def get_marginal_factor(self, elimination_order_method="random", **kwargs):
+        if elimination_order_method == "random":
+            elimination_order = copy(self.model.variables)
+            random.shuffle(elimination_order)
+        elif elimination_order_method == "not_random":
+            elimination_order = copy(self.model.variables)
+        elif elimination_order_method == "given":
+            elimination_order = kwargs["elimination_order"]
+
+        if "exception_variables" in kwargs:
+            exception_variables = kwargs["exception_variables"]
+        else:
+            exception_variables = []
+
+        eliminated_model = self.model.copy()
+        max_ibound = 0
+        for var in elimination_order:
+            if var not in exception_variables:
+                max_ibound = max(
+                    max_ibound,
+                    get_bucket_size([fac for fac in eliminated_model.get_adj_factors(var)]),
+                )
+                eliminated_model.contract_variable(var)
+
+        final_factor = product_over_(*eliminated_model.factors)
+        if "exception_variables" in kwargs:
+            final_factor.transpose_by_(exception_variables)
+
+        return final_factor
+
+
+def get_bucket_size(bucket):
+    s = set()
+    for fac in bucket:
+        s = s.union(set(fac.variables))
+
+    return len(s)

--- a/inferlo/generic/inference/bucket_elimination.py
+++ b/inferlo/generic/inference/bucket_elimination.py
@@ -1,11 +1,7 @@
-import sys
-import numpy as np
 import random
-from functools import reduce
 from copy import copy
 
-sys.path.extend(["graphical_model/"])
-from factor import Factor, product_over_
+from inferlo.generic.inference.factor  import Factor, product_over_
 
 
 class BucketElimination:

--- a/inferlo/generic/inference/bucket_renormalization.py
+++ b/inferlo/generic/inference/bucket_renormalization.py
@@ -1,12 +1,9 @@
 import numpy as np
-from copy import copy
-import random
-import sys
 
-sys.path.extend(["graphical_model/"])
-from factor import Factor, default_factor_name, product_over_
-from bucket_elimination import BucketElimination
-from mini_bucket_elimination import MiniBucketElimination
+
+from .factor import Factor, default_factor_name, product_over_
+from .bucket_elimination import BucketElimination
+from .mini_bucket_elimination import MiniBucketElimination
 from sklearn.utils.extmath import randomized_svd
 
 

--- a/inferlo/generic/inference/bucket_renormalization.py
+++ b/inferlo/generic/inference/bucket_renormalization.py
@@ -1,14 +1,21 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
-
-
-from .factor import Factor, default_factor_name, product_over_
-from .bucket_elimination import BucketElimination
-from .mini_bucket_elimination import MiniBucketElimination
 from sklearn.utils.extmath import randomized_svd
+
+from inferlo.base.graph_model import GraphModel
+from .bucket_elimination import BucketElimination
+from .factor import Factor, default_factor_name, product_over_
+from .mini_bucket_elimination import MiniBucketElimination
 
 
 class BucketRenormalization(MiniBucketElimination):
-    def __init__(self, model, **kwargs):
+    """
+    Reference: Bucket Renormalization for Approximate Inference, 2018.
+      https://arxiv.org/abs/1803.05104
+    """
+
+    def __init__(self, model: 'GraphModel', **kwargs):
         super(BucketRenormalization, self).__init__(model, **kwargs)
         self.initialize_projectors()
 
@@ -27,11 +34,14 @@ class BucketRenormalization(MiniBucketElimination):
                     projector.variables = [main_rvar]
                     projector.name = "P_{}".format(rvar)
 
-                    replications[rvar] = (main_rvar, replicated_projector, projector)
+                    replications[rvar] = (
+                    main_rvar, replicated_projector, projector)
                     main_projectors.append(projector)
 
-                    working_model.add_factors_from([replicated_projector.copy(), projector.copy()])
-                    self.renormalized_model.add_factors_from([replicated_projector, projector])
+                    working_model.add_factors_from(
+                        [replicated_projector.copy(), projector.copy()])
+                    self.renormalized_model.add_factors_from(
+                        [replicated_projector, projector])
 
                 working_model.contract_variable(rvar)
 
@@ -41,22 +51,26 @@ class BucketRenormalization(MiniBucketElimination):
         for var in reversed(self.renormalized_elimination_order):
             if var in self.replications.keys():
                 mb_var, projector, mb_projector = self.replications[var]
-                self.renormalized_model.remove_factors_from([projector, mb_projector])
+                self.renormalized_model.remove_factors_from(
+                    [projector, mb_projector])
                 be = BucketElimination(self.renormalized_model)
                 marginal_factor = be.get_marginal_factor(
                     elimination_order_method="given",
                     elimination_order=self.renormalized_elimination_order,
                     exception_variables=[var, mb_var],
                 )
-                new_mb_projector = self._get_svd_projector(marginal_factor, mb_var)
+                new_mb_projector = self._get_svd_projector(marginal_factor,
+                                                           mb_var)
                 new_projector = Factor(
                     name=default_factor_name(),
                     variables=[var],
                     log_values=new_mb_projector.log_values,
                 )
 
-                self.renormalized_model.add_factors_from([new_projector, new_mb_projector])
-                self.replications[var] = (mb_var, new_projector, new_mb_projector)
+                self.renormalized_model.add_factors_from(
+                    [new_projector, new_mb_projector])
+                self.replications[var] = (
+                mb_var, new_projector, new_mb_projector)
 
     def run(self, max_iter=10):
         for t in range(max_iter):
@@ -68,20 +82,23 @@ class BucketRenormalization(MiniBucketElimination):
         be = BucketElimination(self.renormalized_model)
         logZ = self.base_logZ
         logZ += be.run(
-            elimination_order_method="given", elimination_order=self.renormalized_elimination_order
+            elimination_order_method="given",
+            elimination_order=self.renormalized_elimination_order
         )
 
         return logZ
 
     def _get_svd_projector(self, factor, variable):
-        factor.transpose_by_([variable, *sorted(set(factor.variables) - set([variable]))])
+        factor.transpose_by_(
+            [variable, *sorted(set(factor.variables) - set([variable]))])
         flattened_factor_log_values = factor.log_values.reshape(
             factor.get_cardinality_for_(variable), -1
         )
 
         if np.isfinite(np.max(flattened_factor_log_values)):
             flattened_factor_values = np.exp(
-                flattened_factor_log_values - np.max(flattened_factor_log_values)
+                flattened_factor_log_values - np.max(
+                    flattened_factor_log_values)
             )
         else:
             raise ValueError()
@@ -96,4 +113,5 @@ class BucketRenormalization(MiniBucketElimination):
         u[u < 0] = 0.0
         u /= np.linalg.norm(u)
 
-        return Factor(name=default_factor_name(), variables=[variable], values=u)
+        return Factor(name=default_factor_name(), variables=[variable],
+                      values=u)

--- a/inferlo/generic/inference/bucket_renormalization.py
+++ b/inferlo/generic/inference/bucket_renormalization.py
@@ -1,0 +1,102 @@
+import numpy as np
+from copy import copy
+import random
+import sys
+
+sys.path.extend(["graphical_model/"])
+from factor import Factor, default_factor_name, product_over_
+from bucket_elimination import BucketElimination
+from mini_bucket_elimination import MiniBucketElimination
+from sklearn.utils.extmath import randomized_svd
+
+
+class BucketRenormalization(MiniBucketElimination):
+    def __init__(self, model, **kwargs):
+        super(BucketRenormalization, self).__init__(model, **kwargs)
+        self.initialize_projectors()
+
+    def initialize_projectors(self):
+        replications = dict()
+        working_model = self.renormalized_model.copy()
+        for var in self.elimination_order:
+            main_rvar = self.variables_replicated_from_[var][-1]
+            main_projectors = []
+            for (i, rvar) in enumerate(self.variables_replicated_from_[var]):
+                if i < len(self.variables_replicated_from_[var]) - 1:
+                    fac = product_over_(*working_model.get_adj_factors(rvar))
+                    replicated_projector = self._get_svd_projector(fac, rvar)
+                    replicated_projector.name = "RP_{}".format(rvar)
+                    projector = replicated_projector.copy()
+                    projector.variables = [main_rvar]
+                    projector.name = "P_{}".format(rvar)
+
+                    replications[rvar] = (main_rvar, replicated_projector, projector)
+                    main_projectors.append(projector)
+
+                    working_model.add_factors_from([replicated_projector.copy(), projector.copy()])
+                    self.renormalized_model.add_factors_from([replicated_projector, projector])
+
+                working_model.contract_variable(rvar)
+
+        self.replications = replications
+
+    def optimize(self):
+        for var in reversed(self.renormalized_elimination_order):
+            if var in self.replications.keys():
+                mb_var, projector, mb_projector = self.replications[var]
+                self.renormalized_model.remove_factors_from([projector, mb_projector])
+                be = BucketElimination(self.renormalized_model)
+                marginal_factor = be.get_marginal_factor(
+                    elimination_order_method="given",
+                    elimination_order=self.renormalized_elimination_order,
+                    exception_variables=[var, mb_var],
+                )
+                new_mb_projector = self._get_svd_projector(marginal_factor, mb_var)
+                new_projector = Factor(
+                    name=default_factor_name(),
+                    variables=[var],
+                    log_values=new_mb_projector.log_values,
+                )
+
+                self.renormalized_model.add_factors_from([new_projector, new_mb_projector])
+                self.replications[var] = (mb_var, new_projector, new_mb_projector)
+
+    def run(self, max_iter=10):
+        for t in range(max_iter):
+            self.optimize()
+
+        return self.get_logZ()
+
+    def get_logZ(self):
+        be = BucketElimination(self.renormalized_model)
+        logZ = self.base_logZ
+        logZ += be.run(
+            elimination_order_method="given", elimination_order=self.renormalized_elimination_order
+        )
+
+        return logZ
+
+    def _get_svd_projector(self, factor, variable):
+        factor.transpose_by_([variable, *sorted(set(factor.variables) - set([variable]))])
+        flattened_factor_log_values = factor.log_values.reshape(
+            factor.get_cardinality_for_(variable), -1
+        )
+
+        if np.isfinite(np.max(flattened_factor_log_values)):
+            flattened_factor_values = np.exp(
+                flattened_factor_log_values - np.max(flattened_factor_log_values)
+            )
+        else:
+            raise ValueError()
+
+        U, _, _ = randomized_svd(flattened_factor_values, n_components=1)
+
+        # U,_,_ = np.linalg.svd(flattened_factor_values)
+        u = U[:, 0]
+        if np.sum(u) < 0:
+            u = -u
+
+        u[u < 0] = 0.0
+        u /= np.linalg.norm(u)
+
+        return Factor(name=default_factor_name(), variables=[variable], values=u)

--- a/inferlo/generic/inference/bucket_renormalization.py
+++ b/inferlo/generic/inference/bucket_renormalization.py
@@ -3,19 +3,15 @@
 import numpy as np
 from sklearn.utils.extmath import randomized_svd
 
-from inferlo.base.graph_model import GraphModel
 from .bucket_elimination import BucketElimination
 from .factor import Factor, default_factor_name, product_over_
+from .graphical_model import GraphicalModel
 from .mini_bucket_elimination import MiniBucketElimination
 
 
 class BucketRenormalization(MiniBucketElimination):
-    """
-    Reference: Bucket Renormalization for Approximate Inference, 2018.
-      https://arxiv.org/abs/1803.05104
-    """
 
-    def __init__(self, model: 'GraphModel', **kwargs):
+    def __init__(self, model: GraphicalModel, **kwargs):
         super(BucketRenormalization, self).__init__(model, **kwargs)
         self.initialize_projectors()
 

--- a/inferlo/generic/inference/factor.py
+++ b/inferlo/generic/inference/factor.py
@@ -1,10 +1,16 @@
-import numpy as np
-from functools import reduce
-from numpy import exp, log, amax, amin, squeeze
 from copy import copy
+from functools import reduce
+
+import numpy as np
+from numpy import exp, log, amax, amin, squeeze
 
 
 class Factor:
+    """
+    Factor representation used by algorithms taken from
+    https://github.com/sungsoo-ahn/bucket-renormalization
+    TODO: use Inferlo's DiscreteFactor instead.
+    """
     def __init__(self, name=None, variables=[], **kwargs):
         if name:
             self.name = name

--- a/inferlo/generic/inference/factor.py
+++ b/inferlo/generic/inference/factor.py
@@ -1,0 +1,423 @@
+import numpy as np
+from functools import reduce
+from numpy import exp, log, amax, amin, squeeze
+from copy import copy
+
+
+class Factor:
+    def __init__(self, name=None, variables=[], **kwargs):
+        if name:
+            self.name = name
+        else:
+            self.name = default_factor_name()
+
+        self.variables = variables
+
+        if "values" in kwargs:
+            values = kwargs["values"]
+
+            with np.errstate(divide="ignore", invalid="ignore"):
+                self.log_values = log(values)
+        elif "log_values" in kwargs:
+            self.log_values = kwargs["log_values"]
+        else:
+            self.log_values = np.array(0.0)
+
+        if len(variables) != self.log_values.ndim:
+            raise ValueError(
+                "Shape {shape} of {name} does not match number {variable_num}.".format(
+                    shape=self.log_values.shape, name=name, variable_num=len(variables)
+                )
+            )
+
+        self.cardinality = list(self.log_values.shape)
+
+    @property
+    def values(self):
+        with np.errstate(over="raise"):
+            values = exp(self.__log_values)
+
+        return values
+
+    @values.setter
+    def values(self, values):
+        if (values < -1e-15).any():
+            raise ValueError("value of factor cannot be negative:{}".format(values))
+        elif (values < 0).any():
+            values[values < 0.0] = 0.0
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            self.log_values = log(values)
+
+    @property
+    def log_values(self):
+        return self.__log_values
+
+    @log_values.setter
+    def log_values(self, log_values):
+        self.__log_values = log_values
+
+    @classmethod
+    def initialize_with_(cls, name, variables, numpy_func, cardinality, **kwargs):
+        return cls(name=name, variables=variables, values=numpy_func(cardinality), **kwargs)
+
+    @classmethod
+    def full_like_(cls, factor, value):
+        return cls(
+            name=copy(factor.name),
+            variables=copy(factor.variables),
+            values=np.full_like(factor.values, value),
+        )
+
+    @classmethod
+    def scalar(cls, value=1.0):
+        return cls("", [], value=np.array(1.0))
+
+    def get_cardinality_for_(self, variable):
+        return self.cardinality[self.variables.index(variable)]
+
+    def get_cardinalities_for_(self, variables):
+        return [self.cardinality[self.variables.index(variable)] for variable in variables]
+
+    def copy(self, rename=False):
+        if rename:
+            return Factor(
+                name=default_factor_name(),
+                variables=copy(self.variables),
+                log_values=np.copy(self.log_values),
+            )
+        else:
+            return Factor(
+                name=copy(self.name),
+                variables=copy(self.variables),
+                log_values=np.copy(self.log_values),
+            )
+
+    def pow(self, w, inplace=True):
+        fac = self if inplace else self.copy()
+        fac.log_values *= w
+
+        if not inplace:
+            return fac
+
+    def log(self, inplace=True):
+        fac = self if inplace else self.copy()
+        fac.log_values = log(fac.log_values)
+        if not inplace:
+            return fac
+
+    def exp(self, inplace=True):
+        fac = self if inplace else self.copy()
+        fac.log_values = exp(fac.log_values)
+        if not inplace:
+            return fac
+
+    def transpose_by_(self, variables, inplace=True):
+        fac = self if inplace else self.copy()
+        new_axes = [fac.variables.index(variable) for variable in variables]
+        fac.log_values = np.transpose(fac.log_values, axes=new_axes)
+        fac.cardinality = list(fac.log_values.shape)
+        fac.variables = variables
+        if not inplace:
+            return fac
+
+    ## Numerically unstable
+    def invT(self, inplace=True):
+        fac = self if inplace else self.copy()
+        fac.values = np.linalg.inv(fac.values).transpose(1, 0)
+        if not inplace:
+            return fac
+
+    def marginalize(self, variables=None, operator="sum", inplace=True, **kwargs):
+        fac = self if inplace else self.copy()
+        if not variables:
+            variables = self.variables
+        for var in variables:
+            if var not in fac.variables:
+                raise ValueError("{variable} not in scope.".format(variable=var))
+
+        variable_indices = tuple([fac.variables.index(var) for var in variables])
+        index_to_keep = sorted(set(range(len(self.variables))) - set(variable_indices))
+
+        fac.variables = [fac.variables[index] for index in index_to_keep]
+        fac.cardinality = [fac.cardinality[index] for index in index_to_keep]
+
+        if operator == "sum":
+            fac.log_values = logsumexp(fac.log_values, axis=variable_indices)
+        elif operator == "weighted_sum":
+            w = kwargs["weight"]
+            if w != 0:
+                fac.log_values /= w
+                fac.log_values = logsumexp(fac.log_values, axis=variable_indices)
+                fac.log_values *= w
+            else:
+                fac.log_values = amax(fac.log_values, axis=variable_indices)
+        elif operator == "max":
+            fac.log_values = amax(fac.log_values, axis=variable_indices)
+        elif operator == "min":
+            fac.log_values = amin(fac.log_values, axis=variable_indices)
+        else:
+            raise ValueError("Unsupported operator.")
+
+        if not inplace:
+            return fac
+
+    def marginalize_except_(self, variables, operator="sum", inplace=True, **kwargs):
+        fac = self if inplace else self.copy()
+        variables_to_marginalize = [var for var in fac.variables if var not in variables]
+        if variables_to_marginalize:
+            fac.marginalize(variables=variables_to_marginalize, operator=operator, **kwargs)
+
+        fac.transpose_by_(variables)
+
+        if not inplace:
+            return fac
+
+    def normalize(self, variables=None, inplace=True):
+        if not variables:
+            variables = self.variables
+        org_variables = copy(self.variables)
+
+        fac = self if inplace else self.copy()
+
+        variable_indices = tuple([fac.variables.index(variable) for variable in variables])
+
+        zero_indices = ~np.isfinite(fac.log_values)
+        with np.errstate(invalid="ignore"):
+            fac.log_values = fac.log_values - logsumexp(
+                fac.log_values, axis=variable_indices, keepdims=True
+            )
+        fac.log_values[zero_indices] = -np.inf
+
+        fac.transpose_by_(org_variables)
+
+        if not inplace:
+            return fac
+
+    def add(self, fac1, inplace=True):
+        fac = self if inplace else self.copy()
+        if isinstance(fac1, (int, float)):
+            max_a = amax(fac.log_values)
+            fac.log_values = np.log(exp(fac.log_values - max_a) + fac1) + max_a
+            fac.log_values += max_a
+        else:
+            a1 = fac1.transpose_by_(fac.variables, inplace=False).log_values
+            max_a = max(amax(a1), amax(fac.log_values))
+            with np.errstate(invalid="raise"):
+                try:
+                    fac.log_values = log(exp(a1 - max_a) + exp(fac.log_values - max_a))
+                except:
+                    print(a1)
+                    print(fac.log_values)
+                    print(max_a)
+
+            fac.log_values += max_a
+
+        if not inplace:
+            fac.name = default_factor_name()
+            return fac
+
+    def sub(self, fac1, name=None, inplace=True):
+        fac = self if inplace else self.copy()
+        if isinstance(fac1, (int, float)):
+            max_a = amax(fac.log_values)
+            fac.log_values = np.log(exp(fac.log_values - max_a) - fac1) + max_a
+            fac.log_values += max_a
+        else:
+            a1 = fac1.transpose_by_(fac.variables, inplace=False).log_values
+            max_a = max(amax(a1), amax(fac.log_values))
+            fac.log_values = log(exp(fac.log_values - max_a) - exp(a1 - max_a))
+            fac.log_values += max_a
+
+        if not inplace:
+            fac.name = default_factor_name()
+            return fac
+
+    def product(self, fac1, name=None, inplace=True):
+        fac = self if inplace else self.copy()
+
+        if isinstance(fac1, (int, float)):
+            with np.errstate(divide="ignore", invalid="ignore"):
+                fac.log_values += log(fac1)
+        else:
+            fac1 = fac1.copy()
+            extra_variables = set(fac1.variables) - set(fac.variables)
+            if extra_variables:
+                slice_ = [slice(None)] * len(fac.variables)
+                slice_.extend([np.newaxis] * len(extra_variables))
+                fac.log_values = fac.log_values[slice_]
+
+                fac.variables.extend(extra_variables)
+                new_variable_card = fac1.get_cardinalities_for_(extra_variables)
+                fac.cardinality = np.append(fac.cardinality, new_variable_card)
+
+            extra_variables = set(fac.variables) - set(fac1.variables)
+            if extra_variables:
+                slice_ = [slice(None)] * len(fac1.variables)
+                slice_.extend([np.newaxis] * len(extra_variables))
+
+                fac1.log_values = fac1.log_values[slice_]
+                fac1.variables.extend(extra_variables)
+            for axis in range(fac.log_values.ndim):
+                exchange_index = fac1.variables.index(fac.variables[axis])
+                fac1.variables[axis], fac1.variables[exchange_index] = (
+                    fac1.variables[exchange_index],
+                    fac1.variables[axis],
+                )
+                fac1.log_values = fac1.log_values.swapaxes(axis, exchange_index)
+
+            fac.log_values = fac.log_values + fac1.log_values
+
+        if not inplace:
+            fac.name = default_factor_name()
+            return fac
+
+    def div(self, fac1, name=None, inplace=True):
+        fac = self if inplace else self.copy()
+
+        if isinstance(fac1, (int, float)):
+            with np.errstate(divide="ignore", invalid="ignore"):
+                fac.log_values += log(fac1)
+        else:
+            fac1 = fac1.copy()
+            extra_variables = set(fac1.variables) - set(fac.variables)
+            if extra_variables:
+                slice_ = [slice(None)] * len(fac.variables)
+                slice_.extend([np.newaxis] * len(extra_variables))
+
+                fac.log_values = fac.log_values[slice_]
+                fac.variables.extend(extra_variables)
+                new_variable_card = fac1.get_cardinalities_for_(extra_variables)
+                fac.cardinality = np.append(fac.cardinality, new_variable_card)
+
+            extra_variables = set(fac.variables) - set(fac1.variables)
+            if extra_variables:
+                slice_ = [slice(None)] * len(fac1.variables)
+                slice_.extend([np.newaxis] * len(extra_variables))
+
+                fac1.log_values = fac1.log_values[slice_]
+                fac1.variables.extend(extra_variables)
+            for axis in range(fac.log_values.ndim):
+                exchange_index = fac1.variables.index(fac.variables[axis])
+                fac1.variables[axis], fac1.variables[exchange_index] = (
+                    fac1.variables[exchange_index],
+                    fac1.variables[axis],
+                )
+                fac1.log_values = fac1.log_values.swapaxes(axis, exchange_index)
+
+            zero_indices = np.logical_and(
+                ~np.isfinite(fac.log_values), ~np.isfinite(fac1.log_values)
+            )
+
+            with np.errstate(invalid="ignore"):
+                fac.log_values = fac.log_values - fac1.log_values
+
+            fac.log_values[zero_indices] = 1.0
+
+    def __pow__(self, w):
+        return self.pow(w, inplace=True)
+
+    def __add__(self, other):
+        return self.add(other, inplace=False)
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __sub__(self, other):
+        return self.sub(other, inplace=False)
+
+    def __rsub__(self, other):
+        return self.__sub__(other)
+
+    def __mul__(self, other):
+        return self.product(other, inplace=False)
+
+    def __div__(self, other):
+        if type(other) == type(self):
+            return self.product(other.pow(-1.0, inplace=False), inplace=False)
+        else:
+            return self.product(1 / other, inplace=False)
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __rdiv(self, other):
+        return self.__div__(other)
+
+    def __eq__(self, other):
+        if not issubclass(type(self), type(other)):
+            return False
+        if self.name == other.name and tuple(sorted(self.variables)) == tuple(
+            sorted(other.variables)
+        ):
+            return True
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.name.join(sorted(self.variables)))
+
+    def __repr__(self):
+        return "Factor: " + self.name + " Variables: " + ", ".join(self.variables)
+
+
+def logsumexp(a, axis=None, keepdims=False):
+    if axis is None:
+        a = a.ravel()
+
+    a_max = amax(a, axis=axis, keepdims=True)
+    if a_max.ndim > 0:
+        a_max[~np.isfinite(a_max)] = 0
+
+    tmp = exp(a - a_max)
+    with np.errstate(divide="ignore"):
+        out = log(np.sum(tmp, axis=axis, keepdims=keepdims))
+
+    if not keepdims:
+        a_max = squeeze(a_max, axis=axis)
+    out += a_max
+    return out
+
+
+def default_factor_name(prefix="_F"):
+    default_factor_name.cnt += 1
+    return prefix + str(default_factor_name.cnt)
+
+
+default_factor_name.cnt = 0
+
+
+def default_variable_name(prefix="_V"):
+    default_variable_name.cnt += 1
+    return prefix + str(default_variable_name.cnt)
+
+
+default_variable_name.cnt = 0
+
+
+def product_over_(*args):
+    factor_list = [tensor for tensor in args if tensor]
+    if len(factor_list) > 1:
+        return reduce(lambda phi1, phi2: phi1 * phi2, factor_list)
+    elif isinstance(factor_list[0], (int, float)):
+        return factor_list[0]
+    else:
+        return factor_list[0].copy()
+
+
+def entropy(p, q=None):
+    p_values = np.copy(p.values)
+    p_values.ravel()
+    index_to_keep = p_values != 0
+    p_values = p_values[index_to_keep]
+    if q:
+        q.transpose_by_(p.variables)
+        q_values = np.copy(q.values)
+        q_values.ravel()
+        q_values = q_values[index_to_keep]
+        return np.sum(p_values * (log(q_values) - log(p_values)))
+    else:
+        return np.sum(-p_values * log(p_values))

--- a/inferlo/generic/inference/factor.py
+++ b/inferlo/generic/inference/factor.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from copy import copy
 from functools import reduce
 
@@ -9,7 +11,7 @@ class Factor:
     """
     Factor representation used by algorithms taken from
     https://github.com/sungsoo-ahn/bucket-renormalization
-    TODO: use Inferlo's DiscreteFactor instead.
+    TODO(fedimser): use Inferlo's DiscreteFactor instead.
     """
 
     def __init__(self, name=None, variables=[], **kwargs):

--- a/inferlo/generic/inference/graphical_model.py
+++ b/inferlo/generic/inference/graphical_model.py
@@ -1,0 +1,152 @@
+from copy import copy
+from .factor import Factor, product_over_
+import numpy as np
+from functools import reduce
+
+from ... import DiscreteFactor, GraphModel
+
+
+class GraphicalModel:
+    def __init__(self, variables=[], factors=[]):
+        if variables:
+            self.variables = variables
+        else:
+            self.variables = []
+
+        self.factors = []
+
+        if factors:
+            for factor in factors:
+                self.add_factor(factor)
+
+    """
+    Variable related operations
+    """
+
+    def add_variable(self, variable):
+        self.variables.append(variable)
+
+    def add_variables_from(self, variables):
+        for variable in variables:
+            self.add_variable(variable)
+
+    def remove_variable(self, variable):
+        self.variables.remove(variable)
+
+    def remove_variables_from(self, variables):
+        for variable in variables:
+            self.variables.remove(variable)
+
+    def get_cardinality_for_(self, variable):
+        factor = next(factor for factor in self.factors if variable in factor.variables)
+        if factor:
+            return factor.get_cardinality_for_(variable)
+        else:
+            raise ValueError("variable not in the model")
+
+    def get_cardinalities_from(self, variables):
+        cardinalities = []
+        for variable in variables:
+            cardinalities.append(self.get_cardinality_for_(variable))
+        return cardinalities
+
+    def contract_variable(self, variable, operator="sum", **kwargs):
+        adj_factors = self.get_adj_factors(variable)
+        new_factor = product_over_(*adj_factors).copy(rename=True)
+        new_factor.marginalize([variable], operator=operator, **kwargs)
+        for factor in adj_factors:
+            self.remove_factor(factor)
+
+        self.remove_variable(variable)
+        self.add_factor(new_factor)
+
+        return new_factor
+
+    def get_adj_factors(self, variable):
+        factor_list = []
+        for factor in self.factors:
+            if variable in factor.variables:
+                factor_list.append(factor)
+
+        return factor_list
+
+    def degree(self, variable):
+        return len(self.get_adj_factors(variable))
+
+    """
+    Factor related operations
+    """
+
+    def add_factor(self, factor):
+        if set(factor.variables) - set(factor.variables).intersection(set(self.variables)):
+            raise ValueError("Factors defined on variable not in the model.")
+        self.factors.append(factor)
+
+    def add_factors_from(self, factors):
+        for factor in factors:
+            self.add_factor(factor)
+
+    def remove_factor(self, factor):
+        self.factors.remove(factor)
+
+    def remove_factors_from(self, factors):
+        for factor in factors:
+            self.factors.remove(factor)
+
+    def get_factor(self, name):
+        for factor in self.factors:
+            if factor.name == name:
+                return factor
+
+    def get_factors_from(self, names):
+        factors = []
+        for factor in self.factors:
+            if factor.name in names:
+                factors.append(factor)
+        return factors
+
+    """
+    GM related operations
+    """
+
+    def copy(self):
+        return GraphicalModel(copy(self.variables), [factor.copy() for factor in self.factors])
+
+    def summary(self):
+        print(np.max([self.get_cardinality_for_(var) for var in self.variables]))
+        print(np.max([len(fac.variables) for fac in self.factors]))
+        print(len([fac for fac in self.factors if len(fac.variables) > 1]))
+
+    def display_factors(self):
+        for fac in self.factors:
+            print(fac)
+
+
+def from_inferlo_model(inferlo_model: GraphModel) -> GraphicalModel:
+    model = GraphicalModel()
+    model.name = 'generated_from_inferlo'
+
+    cardinalities = dict()
+    for t in range(inferlo_model.num_variables):
+        newvar = "V" + str(t)
+        model.add_variable(newvar)
+        cardinalities[newvar] = inferlo_model.get_variable(t).domain.size()
+
+    factors = list(inferlo_model.get_factors())
+    for factor_id in range(len(factors)):
+        factor = DiscreteFactor.from_factor(factors[factor_id])
+        factor_variables = []
+        for var_id in factor.var_idx:
+            factor_variables.append("V" + str(var_id))
+
+        model.add_factor(Factor(name="F" + str(factor_id),
+                                variables=factor_variables,
+                                values=factor.values))
+
+    return model
+
+def check_forney(gm):
+    for variable in gm.variables:
+        if gm.degree(variable) != 2:
+            return False
+    return True

--- a/inferlo/generic/inference/graphical_model.py
+++ b/inferlo/generic/inference/graphical_model.py
@@ -127,30 +127,6 @@ class GraphicalModel:
         for fac in self.factors:
             print(fac)
 
-    @staticmethod
-    def from_inferlo_model(inferlo_model: GraphModel) -> 'GraphicalModel':
-        model = GraphicalModel()
-        model.name = 'generated_from_inferlo'
-
-        cardinalities = dict()
-        for t in range(inferlo_model.num_variables):
-            newvar = "V" + str(t)
-            model.add_variable(newvar)
-            cardinalities[newvar] = inferlo_model.get_variable(t).domain.size()
-
-        factors = list(inferlo_model.get_factors())
-        for factor_id in range(len(factors)):
-            factor = DiscreteFactor.from_factor(factors[factor_id])
-            factor_variables = []
-            for var_id in factor.var_idx:
-                factor_variables.append("V" + str(var_id))
-
-            model.add_factor(Factor(name="F" + str(factor_id),
-                                    variables=factor_variables,
-                                    values=factor.values))
-
-        return model
-
 def check_forney(gm):
     for variable in gm.variables:
         if gm.degree(variable) != 2:

--- a/inferlo/generic/inference/graphical_model.py
+++ b/inferlo/generic/inference/graphical_model.py
@@ -1,10 +1,11 @@
 # Copyright (c) The InferLO authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 - see LICENSE.
 from copy import copy
+from typing import List
 
 import numpy as np
 
-from .factor import product_over_
+from .factor import product_over_, Factor
 
 
 class GraphicalModel:
@@ -13,50 +14,51 @@ class GraphicalModel:
     https://github.com/sungsoo-ahn/bucket-renormalization
     TODO(fedimser): use Inferlo's GraphModel instead.
     """
-    def __init__(self, variables=[], factors=[]):
-        if variables:
-            self.variables = variables
-        else:
-            self.variables = []
 
-        self.factors = []
-
-        if factors:
-            for factor in factors:
-                self.add_factor(factor)
+    def __init__(self, variables: List[str], factors: List[Factor]):
+        self.variables = variables
+        self.factors = factors
 
     """
     Variable related operations
     """
 
-    def add_variable(self, variable):
+    def add_variable(self, variable: str):
+        """Adds variable."""
         self.variables.append(variable)
 
     def add_variables_from(self, variables):
+        """Adds multiple variables."""
         for variable in variables:
             self.add_variable(variable)
 
     def remove_variable(self, variable):
+        """Removes variable."""
         self.variables.remove(variable)
 
     def remove_variables_from(self, variables):
+        """Removes multiple variables."""
         for variable in variables:
             self.variables.remove(variable)
 
     def get_cardinality_for_(self, variable):
-        factor = next(factor for factor in self.factors if variable in factor.variables)
+        """Returns cardinality of a variable."""
+        factor = next(
+            factor for factor in self.factors if variable in factor.variables)
         if factor:
             return factor.get_cardinality_for_(variable)
         else:
             raise ValueError("variable not in the model")
 
     def get_cardinalities_from(self, variables):
+        """Returns cardinalities for given variables."""
         cardinalities = []
         for variable in variables:
             cardinalities.append(self.get_cardinality_for_(variable))
         return cardinalities
 
     def contract_variable(self, variable, operator="sum", **kwargs):
+        """Contracts variable."""
         adj_factors = self.get_adj_factors(variable)
         new_factor = product_over_(*adj_factors).copy(rename=True)
         new_factor.marginalize([variable], operator=operator, **kwargs)
@@ -69,6 +71,7 @@ class GraphicalModel:
         return new_factor
 
     def get_adj_factors(self, variable):
+        """Retruns all factors depending on given variable."""
         factor_list = []
         for factor in self.factors:
             if variable in factor.variables:
@@ -77,34 +80,42 @@ class GraphicalModel:
         return factor_list
 
     def degree(self, variable):
+        """Returns number of vactors depending on given variable."""
         return len(self.get_adj_factors(variable))
 
     """
     Factor related operations
     """
 
-    def add_factor(self, factor):
-        if set(factor.variables) - set(factor.variables).intersection(set(self.variables)):
+    def add_factor(self, factor: Factor):
+        """Adds a factor."""
+        if set(factor.variables) - \
+                set(factor.variables).intersection(set(self.variables)):
             raise ValueError("Factors defined on variable not in the model.")
         self.factors.append(factor)
 
     def add_factors_from(self, factors):
+        """Adds multiple factors."""
         for factor in factors:
             self.add_factor(factor)
 
     def remove_factor(self, factor):
+        """Removes a factor."""
         self.factors.remove(factor)
 
     def remove_factors_from(self, factors):
+        """Removes multiple factors."""
         for factor in factors:
             self.factors.remove(factor)
 
     def get_factor(self, name):
+        """Gets factor by name."""
         for factor in self.factors:
             if factor.name == name:
                 return factor
 
     def get_factors_from(self, names):
+        """Gets factors by their names."""
         factors = []
         for factor in self.factors:
             if factor.name in names:
@@ -116,19 +127,18 @@ class GraphicalModel:
     """
 
     def copy(self) -> 'GraphicalModel':
-        return GraphicalModel(copy(self.variables), [factor.copy() for factor in self.factors])
+        """Makes copy of this model."""
+        return GraphicalModel(copy(self.variables),
+                              [factor.copy() for factor in self.factors])
 
     def summary(self):
-        print(np.max([self.get_cardinality_for_(var) for var in self.variables]))
+        """Print summary about this model."""
+        print(np.max([self.get_cardinality_for_(var)
+                      for var in self.variables]))
         print(np.max([len(fac.variables) for fac in self.factors]))
         print(len([fac for fac in self.factors if len(fac.variables) > 1]))
 
     def display_factors(self):
+        """Prints all factors."""
         for fac in self.factors:
             print(fac)
-
-def check_forney(gm):
-    for variable in gm.variables:
-        if gm.degree(variable) != 2:
-            return False
-    return True

--- a/inferlo/generic/inference/graphical_model.py
+++ b/inferlo/generic/inference/graphical_model.py
@@ -1,17 +1,17 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from copy import copy
 
 import numpy as np
 
-from inferlo.base.factors.discrete_factor import DiscreteFactor
-from inferlo.base.graph_model import GraphModel
-from .factor import Factor, product_over_
+from .factor import product_over_
 
 
 class GraphicalModel:
     """
     Graphical model representation used by algorithms taken from
     https://github.com/sungsoo-ahn/bucket-renormalization
-    TODO: use Inferlo's GraphModel instead.
+    TODO(fedimser): use Inferlo's GraphModel instead.
     """
     def __init__(self, variables=[], factors=[]):
         if variables:

--- a/inferlo/generic/inference/inference.py
+++ b/inferlo/generic/inference/inference.py
@@ -1,0 +1,117 @@
+from inferlo import GraphModel, DiscreteFactor
+from .belief_propagation import BeliefPropagation, IterativeJoinGraphPropagation
+from .bucket_elimination import BucketElimination
+from .bucket_renormalization import BucketRenormalization
+from .factor import Factor
+from .graphical_model import GraphicalModel
+from .mean_field import MeanField
+from .mini_bucket_elimination import MiniBucketElimination
+from .weighted_mini_bucket_elimination import WeightedMiniBucketElimination
+
+
+def _convert(inferlo_model: GraphModel) -> GraphicalModel:
+    model = GraphicalModel()
+    cardinalities = dict()
+    for t in range(inferlo_model.num_variables):
+        newvar = "V" + str(t)
+        model.add_variable(newvar)
+        cardinalities[newvar] = inferlo_model.get_variable(t).domain.size()
+
+    factors = list(inferlo_model.get_factors())
+    for factor_id in range(len(factors)):
+        factor = DiscreteFactor.from_factor(factors[factor_id])
+        factor_variables = []
+        for var_id in factor.var_idx:
+            factor_variables.append("V" + str(var_id))
+        model.add_factor(Factor(name="F" + str(factor_id),
+                                variables=factor_variables,
+                                values=factor.values))
+    return model
+
+
+def belief_propagation(model: GraphModel) -> float:
+    """Inference with Belief Propagation.
+
+    Estimates partition function using Loopy Belief Propagation algorithm.
+
+    Original implementation from https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/belief_propagation.py
+
+    :param model: Model for which to perform inference.
+    :return: Natural logarithm of estimated partition function.
+    """
+    return BeliefPropagation(_convert(model)).run()
+
+
+def bucket_elimination(model: GraphModel) -> float:
+    """Inference with Bucket Elimination.
+
+    Estimates partition function using Bucket Elimination algorithm.
+
+    Original implementation from https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/bucket_elimination.py
+
+    :param model: Model for which to perform inference.
+    :return: Natural logarithm of estimated partition function.
+
+    Reference
+        Yedidia, Jonathan S, Freeman, William T, and Weiss, Yair.
+        Generalized belief propagation. In Advances in neural
+        information processing systems, pp. 689–695, 2001
+        https://ieeexplore.ieee.org/document/910572
+    """
+    return BucketElimination(_convert(model)).run()
+
+
+def bucket_renormalization(model: GraphModel,
+                           ibound: int = 10,
+                           max_iter: int = 0) -> float:
+    """
+    Reference: Bucket Renormalization for Approximate Inference, 2018.
+      https://arxiv.org/abs/1803.05104
+
+    max_iter: 0-"MBR", 1-"GBR".
+    """
+    algo = BucketRenormalization(_convert(model), ibound=ibound)
+    return algo.run(max_iter=max_iter)
+
+
+def iterative_join_graph_propagation(model: GraphModel,
+                                     ibound: int = 10) -> float:
+    """Inference with Iterative Join Graph Propagation.
+
+    :param model: Model for which to perform inference.
+    :return: Natural logarithm of estimated partition function.
+
+
+    https://arxiv.org/abs/1301.0564
+    """
+    return IterativeJoinGraphPropagation(_convert(model), ibound=ibound).run()
+
+
+def mean_field(model: GraphModel) -> float:
+    """Inference with Mean Field.
+
+    :param model: Model for which to perform inference.
+    :return: Natural logarithm of estimated partition function.
+    """
+    return MeanField(_convert(model)).run()
+
+
+def mini_bucket_elimination(model: GraphModel, ibound: int = 10) -> float:
+    """Inference with Mean Field.
+
+    :param model: Model for which to perform inference.
+    :param ibound:
+    :return: Natural logarithm of estimated partition function.
+    """
+    return MiniBucketElimination(_convert(model), ibound=ibound).run()
+
+
+def weighted_mini_bucket_elimination(model: GraphModel,
+                                     ibound: int = 10) -> float:
+    """Inference with Weighted Mini Bucket Elimination.
+
+    :param model: Model for which to perform inference.
+    :param ibound:
+    :return: Natural logarithm of estimated partition function.
+    """
+    return WeightedMiniBucketElimination(_convert(model), ibound=ibound).run()

--- a/inferlo/generic/inference/inference.py
+++ b/inferlo/generic/inference/inference.py
@@ -31,17 +31,27 @@ def _convert(inferlo_model: GraphModel) -> GraphicalModel:
     return model
 
 
-def belief_propagation(model: GraphModel) -> float:
-    """Inference with Belief Propagation.
+def belief_propagation(model: GraphModel,
+                       max_iter: int = 1000,
+                       converge_thr: float = 1e-5,
+                       damp_ratio: float = 0.1) -> float:
+    """Inference with (loopy) Belief Propagation.
 
     Estimates partition function using Loopy Belief Propagation algorithm.
 
-    Original implementation from https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/belief_propagation.py
-
     :param model: Model for which to perform inference.
+    :param max_iter: Number of iterations.
+    :param converge_thr: Convergence threshold.
+    :param damp_ratio: Damp ratio.
     :return: Natural logarithm of estimated partition function.
+
+    References
+        [1] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/belief_propagation.py>`_.
     """
-    return BeliefPropagation(_convert(model)).run()
+    algo = BeliefPropagation(_convert(model))
+    return algo.run(max_iter=max_iter, converge_thr=converge_thr,
+             damp_ratio=damp_ratio)
 
 
 def bucket_elimination(model: GraphModel) -> float:
@@ -49,16 +59,16 @@ def bucket_elimination(model: GraphModel) -> float:
 
     Estimates partition function using Bucket Elimination algorithm.
 
-    Original implementation from https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/bucket_elimination.py
-
     :param model: Model for which to perform inference.
     :return: Natural logarithm of estimated partition function.
 
-    Reference
-        Dechter, Rina.
-        Bucket elimination: A unifying framework for reasoning.
-        Artificial Intelligence, 113(1):41–85, 1999.
+    References
+        [1] Rina Dechter.
+        Bucket elimination: A unifying framework for reasoning. 1999.
         https://arxiv.org/abs/1302.3572
+
+        [2] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/bucket_elimination.py>`_.
     """
     return BucketElimination(_convert(model)).run()
 
@@ -68,6 +78,8 @@ def bucket_renormalization(model: GraphModel,
                            max_iter: int = 1) -> float:
     """Inference with Bucket Renormalization.
 
+    Estimates partition function using Bucket Renormalization algorithm.
+
     :param model: Model for which to perform inference.
     :param ibound: Maximal size of mini-bucket.
     :param max_iter: Number of optimization iterations. 0 corresponds to
@@ -75,43 +87,79 @@ def bucket_renormalization(model: GraphModel,
         Renormalization. Default is 1.
     :return: Natural logarithm of estimated partition function.
 
-    Reference
-        Sungsoo Ahn, Michael Chertkov, Adrian Weller, Jinwoo Shin
-        Bucket Renormalization for Approximate Inference, 2018.
+    References
+        [1] Sungsoo Ahn, Michael Chertkov, Adrian Weller, Jinwoo Shin.
+        Bucket Renormalization for Approximate Inference. 2018.
         https://arxiv.org/abs/1803.05104
+
+        [2] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/bucket_renormalization.py>`_.
     """
     algo = BucketRenormalization(_convert(model), ibound=ibound)
     return algo.run(max_iter=max_iter)
 
 
 def iterative_join_graph_propagation(model: GraphModel,
-                                     ibound: int = 10) -> float:
+                                     ibound: int = 10,
+                                     max_iter: int = 1000,
+                                     converge_thr: float = 1e-5,
+                                     damp_ratio: float = 0.1) -> float:
     """Inference with Iterative Join Graph Propagation.
 
+    Estimates partition function using Iterative Join Graph Propagation
+      algorithm, which belongs to the class of Generalized Belief Propagation
+      methods.
+
     :param model: Model for which to perform inference.
+    :param max_iter: Number of iterations.
+    :param converge_thr: Convergence threshold.
+    :param damp_ratio: Damp ratio.
     :return: Natural logarithm of estimated partition function.
 
+    References
+        [1] Rina Dechter, Kalev Kask, Robert Mateescu.
+        Iterative Join-Graph Propagation. 2012.
+        https://arxiv.org/abs/1301.0564
 
-    https://arxiv.org/abs/1301.0564
+        [2] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/belief_propagation.py>`_.
     """
-    return IterativeJoinGraphPropagation(_convert(model), ibound=ibound).run()
+    algo = IterativeJoinGraphPropagation(_convert(model), ibound=ibound)
+    return algo.run(max_iter=max_iter, converge_thr=converge_thr,
+                    damp_ratio=damp_ratio)
 
 
 def mean_field(model: GraphModel) -> float:
     """Inference with Mean Field.
 
+    Estimates partition function using Mean Field approximation.
+
     :param model: Model for which to perform inference.
     :return: Natural logarithm of estimated partition function.
+
+    References
+        [1] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/mean_field.py>`_.
     """
     return MeanField(_convert(model)).run()
 
 
 def mini_bucket_elimination(model: GraphModel, ibound: int = 10) -> float:
-    """Inference with Mean Field.
+    """Inference with Mini Bucket Elimination.
+
+    Estimates partition function using Mini Bucket Elimination algorithm.
 
     :param model: Model for which to perform inference.
-    :param ibound:
+    :param ibound: Maximal size of mini-bucket.
     :return: Natural logarithm of estimated partition function.
+
+    References
+        [1] Rina Dechter, Irina Rish.
+        Mini-buckets: A general scheme for bounded inference. 2003.
+        https://dl.acm.org/doi/abs/10.1145/636865.636866
+
+        [2] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/mini_bucket_elimination.py>`_.
     """
     return MiniBucketElimination(_convert(model), ibound=ibound).run()
 
@@ -120,8 +168,17 @@ def weighted_mini_bucket_elimination(model: GraphModel,
                                      ibound: int = 10) -> float:
     """Inference with Weighted Mini Bucket Elimination.
 
+    Estimates partition function using MWeighted Mini Bucket Elimination
+      algorithm.
+
     :param model: Model for which to perform inference.
-    :param ibound:
+    :param ibound: Maximal size of mini-bucket.
     :return: Natural logarithm of estimated partition function.
+
+    References
+        [1] Qiang Liu, Alexander T. Ihler.
+        Bounding the Partition Function using Holder's Inequality. 2011.
+        [2] `Original implementation
+        <https://github.com/sungsoo-ahn/bucket-renormalization/blob/master/inference/weighted_mini_bucket_elimination.py>`_.
     """
     return WeightedMiniBucketElimination(_convert(model), ibound=ibound).run()

--- a/inferlo/generic/inference/inference.py
+++ b/inferlo/generic/inference/inference.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from inferlo import GraphModel, DiscreteFactor
 from .belief_propagation import BeliefPropagation, IterativeJoinGraphPropagation
 from .bucket_elimination import BucketElimination
@@ -53,22 +55,30 @@ def bucket_elimination(model: GraphModel) -> float:
     :return: Natural logarithm of estimated partition function.
 
     Reference
-        Yedidia, Jonathan S, Freeman, William T, and Weiss, Yair.
-        Generalized belief propagation. In Advances in neural
-        information processing systems, pp. 689–695, 2001
-        https://ieeexplore.ieee.org/document/910572
+        Dechter, Rina.
+        Bucket elimination: A unifying framework for reasoning.
+        Artificial Intelligence, 113(1):41–85, 1999.
+        https://arxiv.org/abs/1302.3572
     """
     return BucketElimination(_convert(model)).run()
 
 
 def bucket_renormalization(model: GraphModel,
                            ibound: int = 10,
-                           max_iter: int = 0) -> float:
-    """
-    Reference: Bucket Renormalization for Approximate Inference, 2018.
-      https://arxiv.org/abs/1803.05104
+                           max_iter: int = 1) -> float:
+    """Inference with Bucket Renormalization.
 
-    max_iter: 0-"MBR", 1-"GBR".
+    :param model: Model for which to perform inference.
+    :param ibound: Maximal size of mini-bucket.
+    :param max_iter: Number of optimization iterations. 0 corresponds to
+        Mini-Bucket Renormalization. 1 corresponds to Global-Bucket
+        Renormalization. Default is 1.
+    :return: Natural logarithm of estimated partition function.
+
+    Reference
+        Sungsoo Ahn, Michael Chertkov, Adrian Weller, Jinwoo Shin
+        Bucket Renormalization for Approximate Inference, 2018.
+        https://arxiv.org/abs/1803.05104
     """
     algo = BucketRenormalization(_convert(model), ibound=ibound)
     return algo.run(max_iter=max_iter)

--- a/inferlo/generic/inference/inference.py
+++ b/inferlo/generic/inference/inference.py
@@ -12,10 +12,10 @@ from .weighted_mini_bucket_elimination import WeightedMiniBucketElimination
 
 
 def _convert(inferlo_model: GraphModel) -> GraphicalModel:
-    model = GraphicalModel()
+    model = GraphicalModel([], [])
     cardinalities = dict()
     for t in range(inferlo_model.num_variables):
-        newvar = "V" + str(t)
+        newvar = "V%d" % t
         model.add_variable(newvar)
         cardinalities[newvar] = inferlo_model.get_variable(t).domain.size()
 
@@ -24,8 +24,8 @@ def _convert(inferlo_model: GraphModel) -> GraphicalModel:
         factor = DiscreteFactor.from_factor(factors[factor_id])
         factor_variables = []
         for var_id in factor.var_idx:
-            factor_variables.append("V" + str(var_id))
-        model.add_factor(Factor(name="F" + str(factor_id),
+            factor_variables.append("V%d" % var_id)
+        model.add_factor(Factor(name="F%d" % factor_id,
                                 variables=factor_variables,
                                 values=factor.values))
     return model
@@ -51,7 +51,7 @@ def belief_propagation(model: GraphModel,
     """
     algo = BeliefPropagation(_convert(model))
     return algo.run(max_iter=max_iter, converge_thr=converge_thr,
-             damp_ratio=damp_ratio)
+                    damp_ratio=damp_ratio)
 
 
 def bucket_elimination(model: GraphModel) -> float:
@@ -129,12 +129,16 @@ def iterative_join_graph_propagation(model: GraphModel,
                     damp_ratio=damp_ratio)
 
 
-def mean_field(model: GraphModel) -> float:
+def mean_field(model: GraphModel,
+               max_iter: int = 1000,
+               converge_thr: float = 1e-2) -> float:
     """Inference with Mean Field.
 
     Estimates partition function using Mean Field approximation.
 
     :param model: Model for which to perform inference.
+    :param max_iter: Maximal number of iterations.
+    :param converge_thr: Convergence threshold.
     :return: Natural logarithm of estimated partition function.
 
     References

--- a/inferlo/generic/inference/inference_test.py
+++ b/inferlo/generic/inference/inference_test.py
@@ -57,4 +57,4 @@ def test_bucket_renormalization_grid_9x9():
     model = grid_potts_model(9, 9, al_size=2, seed=0)
     true_log_pf = model.infer(algorithm="path_dp").log_pf
     assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf,
-                       atol=1.0)
+                       atol=2.0)

--- a/inferlo/generic/inference/inference_test.py
+++ b/inferlo/generic/inference/inference_test.py
@@ -13,10 +13,14 @@ def test_all_tree_30():
     true_log_pf = model.infer(algorithm="tree_dp").log_pf
     assert np.allclose(inf.mean_field(model), true_log_pf, atol=40.0)
     assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=1e-5)
-    assert np.allclose(inf.iterative_join_graph_propagation(model), true_log_pf)
+    assert np.allclose(
+        inf.iterative_join_graph_propagation(model),
+        true_log_pf)
     assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf)
     assert np.allclose(inf.bucket_elimination(model), true_log_pf)
-    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf)
+    assert np.allclose(
+        inf.weighted_mini_bucket_elimination(model),
+        true_log_pf)
     assert np.allclose(inf.bucket_renormalization(model), true_log_pf)
 
 
@@ -25,13 +29,20 @@ def test_all_grid_6x6():
     true_log_pf = model.infer(algorithm="junction_tree").log_pf
     assert np.allclose(inf.mean_field(model), true_log_pf, atol=20.0)
     assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=0.1)
-    assert np.allclose(inf.iterative_join_graph_propagation(model), true_log_pf)
+    assert np.allclose(
+        inf.iterative_join_graph_propagation(model),
+        true_log_pf)
     assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf,
                        atol=10.0)
     assert np.allclose(inf.bucket_elimination(model), true_log_pf)
-    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf,
-                       atol=10.0)
-    assert np.allclose(inf.bucket_renormalization(model), true_log_pf, atol=0.1)
+    assert np.allclose(
+        inf.weighted_mini_bucket_elimination(model),
+        true_log_pf,
+        atol=10.0)
+    assert np.allclose(
+        inf.bucket_renormalization(model),
+        true_log_pf,
+        atol=0.1)
 
 
 def test_all_clique_6():
@@ -39,22 +50,31 @@ def test_all_clique_6():
     true_log_pf = model.infer(algorithm="junction_tree").log_pf
     assert np.allclose(inf.mean_field(model), true_log_pf, atol=10.0)
     assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=0.1)
-    assert np.allclose(inf.iterative_join_graph_propagation(model), true_log_pf,
-                       atol=1e-4)
+    assert np.allclose(
+        inf.iterative_join_graph_propagation(model),
+        true_log_pf,
+        atol=1e-4)
     assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf)
     assert np.allclose(inf.bucket_elimination(model), true_log_pf)
-    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf)
+    assert np.allclose(
+        inf.weighted_mini_bucket_elimination(model),
+        true_log_pf)
     assert np.allclose(inf.bucket_renormalization(model), true_log_pf)
 
 
 def test_wmbe_grid_9x9():
     model = grid_potts_model(9, 9, al_size=2, seed=0)
     true_log_pf = model.infer(algorithm="path_dp").log_pf
-    assert np.allclose(inf.bucket_renormalization(model), true_log_pf, atol=1.0)
+    assert np.allclose(
+        inf.bucket_renormalization(model),
+        true_log_pf,
+        atol=1.0)
 
 
 def test_bucket_renormalization_grid_9x9():
     model = grid_potts_model(9, 9, al_size=2, seed=0)
     true_log_pf = model.infer(algorithm="path_dp").log_pf
-    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf,
-                       atol=2.0)
+    assert np.allclose(
+        inf.weighted_mini_bucket_elimination(model),
+        true_log_pf,
+        atol=2.0)

--- a/inferlo/generic/inference/inference_test.py
+++ b/inferlo/generic/inference/inference_test.py
@@ -1,6 +1,5 @@
 # Copyright (c) The InferLO authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 - see LICENSE.
-
 import numpy as np
 
 from inferlo.generic import inference as inf

--- a/inferlo/generic/inference/inference_test.py
+++ b/inferlo/generic/inference/inference_test.py
@@ -1,0 +1,60 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
+
+import numpy as np
+
+from inferlo.generic import inference as inf
+from inferlo.testing import grid_potts_model, tree_potts_model, \
+    clique_potts_model
+
+
+def test_all_tree_30():
+    model = tree_potts_model(30, al_size=4, seed=101)
+    true_log_pf = model.infer(algorithm="tree_dp").log_pf
+    assert np.allclose(inf.mean_field(model), true_log_pf, atol=40.0)
+    assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=1e-5)
+    assert np.allclose(inf.iterative_join_graph_propagation(model), true_log_pf)
+    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.bucket_renormalization(model), true_log_pf)
+
+
+def test_all_grid_6x6():
+    model = grid_potts_model(6, 6, al_size=2, seed=101)
+    true_log_pf = model.infer(algorithm="junction_tree").log_pf
+    assert np.allclose(inf.mean_field(model), true_log_pf, atol=20.0)
+    assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=0.1)
+    assert np.allclose(inf.iterative_join_graph_propagation(model), true_log_pf)
+    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf,
+                       atol=10.0)
+    assert np.allclose(inf.bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf,
+                       atol=10.0)
+    assert np.allclose(inf.bucket_renormalization(model), true_log_pf, atol=0.1)
+
+
+def test_all_clique_6():
+    model = clique_potts_model(gr_size=6, al_size=3, seed=101)
+    true_log_pf = model.infer(algorithm="junction_tree").log_pf
+    assert np.allclose(inf.mean_field(model), true_log_pf, atol=10.0)
+    assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=0.1)
+    assert np.allclose(inf.iterative_join_graph_propagation(model), true_log_pf,
+                       atol=1e-4)
+    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf)
+    assert np.allclose(inf.bucket_renormalization(model), true_log_pf)
+
+
+def test_wmbe_grid_9x9():
+    model = grid_potts_model(9, 9, al_size=2, seed=0)
+    true_log_pf = model.infer(algorithm="path_dp").log_pf
+    assert np.allclose(inf.bucket_renormalization(model), true_log_pf, atol=1.0)
+
+
+def test_bucket_renormalization_grid_9x9():
+    model = grid_potts_model(9, 9, al_size=2, seed=0)
+    true_log_pf = model.infer(algorithm="path_dp").log_pf
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model), true_log_pf,
+                       atol=1.0)

--- a/inferlo/generic/inference/inference_test.py
+++ b/inferlo/generic/inference/inference_test.py
@@ -12,15 +12,15 @@ def test_all_tree_30():
     true_log_pf = model.infer(algorithm="tree_dp").log_pf
     assert np.allclose(inf.mean_field(model), true_log_pf, atol=40.0)
     assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=1e-5)
-    assert np.allclose(
-        inf.iterative_join_graph_propagation(model),
-        true_log_pf)
-    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf)
-    assert np.allclose(inf.bucket_elimination(model), true_log_pf)
-    assert np.allclose(
-        inf.weighted_mini_bucket_elimination(model),
-        true_log_pf)
-    assert np.allclose(inf.bucket_renormalization(model), true_log_pf)
+    assert np.allclose(inf.iterative_join_graph_propagation(model),
+                       true_log_pf, atol=1e-5)
+    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf,
+                       atol=1e-5)
+    assert np.allclose(inf.bucket_elimination(model), true_log_pf, atol=1e-5)
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model),
+                       true_log_pf, atol=0.5)
+    assert np.allclose(inf.bucket_renormalization(model), true_log_pf,
+                       atol=1e-5)
 
 
 def test_all_grid_6x6():
@@ -28,20 +28,17 @@ def test_all_grid_6x6():
     true_log_pf = model.infer(algorithm="junction_tree").log_pf
     assert np.allclose(inf.mean_field(model), true_log_pf, atol=20.0)
     assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=0.1)
-    assert np.allclose(
-        inf.iterative_join_graph_propagation(model),
-        true_log_pf)
+    assert np.allclose(inf.iterative_join_graph_propagation(model),
+                       true_log_pf, atol=1e-5)
     assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf,
                        atol=10.0)
-    assert np.allclose(inf.bucket_elimination(model), true_log_pf)
-    assert np.allclose(
-        inf.weighted_mini_bucket_elimination(model),
-        true_log_pf,
-        atol=10.0)
-    assert np.allclose(
-        inf.bucket_renormalization(model),
-        true_log_pf,
-        atol=0.1)
+    assert np.allclose(inf.bucket_elimination(model), true_log_pf, atol=1e-5)
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model),
+                       true_log_pf,
+                       atol=10.0)
+    assert np.allclose(inf.bucket_renormalization(model),
+                       true_log_pf,
+                       atol=0.1)
 
 
 def test_all_clique_6():
@@ -49,16 +46,16 @@ def test_all_clique_6():
     true_log_pf = model.infer(algorithm="junction_tree").log_pf
     assert np.allclose(inf.mean_field(model), true_log_pf, atol=10.0)
     assert np.allclose(inf.belief_propagation(model), true_log_pf, atol=0.1)
-    assert np.allclose(
-        inf.iterative_join_graph_propagation(model),
-        true_log_pf,
-        atol=1e-4)
-    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf)
-    assert np.allclose(inf.bucket_elimination(model), true_log_pf)
-    assert np.allclose(
-        inf.weighted_mini_bucket_elimination(model),
-        true_log_pf)
-    assert np.allclose(inf.bucket_renormalization(model), true_log_pf)
+    assert np.allclose(inf.iterative_join_graph_propagation(model),
+                       true_log_pf,
+                       atol=1e-4)
+    assert np.allclose(inf.mini_bucket_elimination(model), true_log_pf,
+                       atol=1e-5)
+    assert np.allclose(inf.bucket_elimination(model), true_log_pf, atol=1e-5)
+    assert np.allclose(inf.weighted_mini_bucket_elimination(model),
+                       true_log_pf, atol=1e-5)
+    assert np.allclose(inf.bucket_renormalization(model), true_log_pf,
+                       atol=1e-5)
 
 
 def test_wmbe_grid_9x9():

--- a/inferlo/generic/inference/mean_field.py
+++ b/inferlo/generic/inference/mean_field.py
@@ -1,10 +1,7 @@
-import sys
 from copy import copy
 import numpy as np
-import time
 
-sys.path.extend(["graphical_model/"])
-from factor import Factor, product_over_, entropy
+from .factor import Factor, product_over_, entropy
 
 
 def default_message_name(prefix="_M"):

--- a/inferlo/generic/inference/mean_field.py
+++ b/inferlo/generic/inference/mean_field.py
@@ -1,23 +1,25 @@
 # Copyright (c) The InferLO authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 - see LICENSE.
+import warnings
 from copy import copy
 
 import numpy as np
 
-from inferlo.base.graph_model import GraphModel
 from .factor import Factor, product_over_, entropy
 from .graphical_model import GraphicalModel
 
 
-def default_message_name(prefix="_M"):
-    default_message_name.cnt += 1
-    return prefix + str(default_message_name.cnt)
+def _default_message_name(prefix="_M"):
+    _default_message_name.cnt += 1
+    return prefix + str(_default_message_name.cnt)
 
 
-default_message_name.cnt = 0
+_default_message_name.cnt = 0
 
 
 class MeanField:
+    """Mean Field algorithm."""
+
     def __init__(self, model: GraphicalModel, **kwargs):
         self.model = model.copy()
 
@@ -32,33 +34,44 @@ class MeanField:
         self.mean_fields = {}
         for var in self.model.variables:
             self.mean_fields[var] = Factor.initialize_with_(
-                default_message_name(), [var], init_np_func, self.model.get_cardinality_for_(var)
-            )
+                _default_message_name(),
+                [var],
+                init_np_func,
+                self.model.get_cardinality_for_(var))
             self.mean_fields[var].normalize()
 
-    def run(self, max_iter=1000, converge_thr=1e-2, verbose=False):
-        for t in range(max_iter):
-            old_mean_field = {var: copy(self.mean_fields[var]) for var in self.model.variables}
+    def run(self, max_iter=1000, converge_thr=1e-2):
+        """Runs the algorithm, returns log(Z)."""
+        converged = False
+        for _ in range(max_iter):
+            old_mean_field = {
+                var: copy(
+                    self.mean_fields[var]) for var in self.model.variables}
             self._update_mean_fields()
-            if self._is_converged(self.mean_fields, old_mean_field, converge_thr):
-                # if verbose:
-                #    print("Mean field converged in {} iterations.".format(t+1))
+            if self._is_converged(
+                    self.mean_fields,
+                    old_mean_field,
+                    converge_thr):
+                converged = True
                 break
 
-        # if verbose and not self._is_converged(self.mean_fields, old_mean_field, converge_thr):
-        #    print("Mean field did not converge after {} iterations.".format(max_iter))
+        if not converged:
+            warnings.warn(
+                "Mean field did not converge after %d iterations." % max_iter)
 
-        return self.get_logZ()
+        return self._get_log_z()
 
-    def get_logZ(self):
+    def _get_log_z(self):
         logZ = 0
         for var in self.model.variables:
             logZ += entropy(self.mean_fields[var])
 
         for fac in self.model.factors:
-            m = product_over_(*[self.mean_fields[var] for var in fac.variables])
+            m = product_over_(*[self.mean_fields[var]
+                                for var in fac.variables])
             index_to_keep = m.values != 0
-            logZ += np.sum(m.values[index_to_keep] * fac.log_values[index_to_keep])
+            logZ += np.sum(m.values[index_to_keep] *
+                           fac.log_values[index_to_keep])
 
         return logZ
 
@@ -73,17 +86,24 @@ class MeanField:
                     values=np.ones(self.model.get_cardinality_for_(var)),
                 )
                 tmp = product_over_(
-                    tmp, *[self.mean_fields[var1] for var1 in fac.variables if var1 != var]
+                    tmp, *[self.mean_fields[var1] for var1 in fac.variables if
+                           var1 != var]
                 )
                 tmp.transpose_by_(fac.variables)
                 tmp.log_values = fac.log_values * tmp.values
-                next_mean_field = next_mean_field + tmp.marginalize_except_([var], inplace=False)
+                next_mean_field = next_mean_field + tmp.marginalize_except_(
+                    [var], inplace=False)
 
-            self.mean_fields[var] = next_mean_field.exp(inplace=False).normalize(inplace=False)
-            self.mean_fields[var].log_values = np.nan_to_num(self.mean_fields[var].log_values)
+            self.mean_fields[var] = next_mean_field.exp(
+                inplace=False).normalize(inplace=False)
+            self.mean_fields[var].log_values = np.nan_to_num(
+                self.mean_fields[var].log_values)
 
     def _is_converged(self, mean_field, old_mean_field, converge_thr):
         for var in self.model.variables:
-            if np.sum(np.abs(mean_field[var].values - old_mean_field[var].values)) > converge_thr:
+            if np.sum(
+                    np.abs(
+                        mean_field[var].values -
+                        old_mean_field[var].values)) > converge_thr:
                 return False
         return True

--- a/inferlo/generic/inference/mean_field.py
+++ b/inferlo/generic/inference/mean_field.py
@@ -1,0 +1,87 @@
+import sys
+from copy import copy
+import numpy as np
+import time
+
+sys.path.extend(["graphical_model/"])
+from factor import Factor, product_over_, entropy
+
+
+def default_message_name(prefix="_M"):
+    default_message_name.cnt += 1
+    return prefix + str(default_message_name.cnt)
+
+
+default_message_name.cnt = 0
+
+
+class MeanField:
+    def __init__(self, model, **kwargs):
+        self.model = model.copy()
+
+        mean_field_init_method = kwargs.get("mean_field_init_method")
+        if mean_field_init_method == "random":
+            init_np_func = np.ones
+        elif mean_field_init_method == "uniform":
+            init_np_func = np.random.random
+        else:
+            init_np_func = np.ones
+
+        self.mean_fields = {}
+        for var in self.model.variables:
+            self.mean_fields[var] = Factor.initialize_with_(
+                default_message_name(), [var], init_np_func, model.get_cardinality_for_(var)
+            )
+            self.mean_fields[var].normalize()
+
+    def run(self, max_iter=1000, converge_thr=1e-2, verbose=False):
+        for t in range(max_iter):
+            old_mean_field = {var: copy(self.mean_fields[var]) for var in self.model.variables}
+            self._update_mean_fields()
+            if self._is_converged(self.mean_fields, old_mean_field, converge_thr):
+                # if verbose:
+                #    print("Mean field converged in {} iterations.".format(t+1))
+                break
+
+        # if verbose and not self._is_converged(self.mean_fields, old_mean_field, converge_thr):
+        #    print("Mean field did not converge after {} iterations.".format(max_iter))
+
+        return self.get_logZ()
+
+    def get_logZ(self):
+        logZ = 0
+        for var in self.model.variables:
+            logZ += entropy(self.mean_fields[var])
+
+        for fac in self.model.factors:
+            m = product_over_(*[self.mean_fields[var] for var in fac.variables])
+            index_to_keep = m.values != 0
+            logZ += np.sum(m.values[index_to_keep] * fac.log_values[index_to_keep])
+
+        return logZ
+
+    def _update_mean_fields(self):
+        variable_order = np.random.permutation(self.model.variables)
+        for var in variable_order:
+            next_mean_field = Factor.full_like_(self.mean_fields[var], 0.0)
+            for fac in self.model.get_adj_factors(var):
+                tmp = Factor(
+                    name="tmp",
+                    variables=[var],
+                    values=np.ones(self.model.get_cardinality_for_(var)),
+                )
+                tmp = product_over_(
+                    tmp, *[self.mean_fields[var1] for var1 in fac.variables if var1 != var]
+                )
+                tmp.transpose_by_(fac.variables)
+                tmp.log_values = fac.log_values * tmp.values
+                next_mean_field = next_mean_field + tmp.marginalize_except_([var], inplace=False)
+
+            self.mean_fields[var] = next_mean_field.exp(inplace=False).normalize(inplace=False)
+            self.mean_fields[var].log_values = np.nan_to_num(self.mean_fields[var].log_values)
+
+    def _is_converged(self, mean_field, old_mean_field, converge_thr):
+        for var in self.model.variables:
+            if np.sum(np.abs(mean_field[var].values - old_mean_field[var].values)) > converge_thr:
+                return False
+        return True

--- a/inferlo/generic/inference/mean_field.py
+++ b/inferlo/generic/inference/mean_field.py
@@ -1,7 +1,12 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from copy import copy
+
 import numpy as np
 
+from inferlo.base.graph_model import GraphModel
 from .factor import Factor, product_over_, entropy
+from .graphical_model import GraphicalModel
 
 
 def default_message_name(prefix="_M"):
@@ -13,8 +18,8 @@ default_message_name.cnt = 0
 
 
 class MeanField:
-    def __init__(self, model, **kwargs):
-        self.model = model.copy()
+    def __init__(self, model:GraphModel, **kwargs):
+        self.model = GraphicalModel.from_inferlo_model(model).copy()
 
         mean_field_init_method = kwargs.get("mean_field_init_method")
         if mean_field_init_method == "random":
@@ -27,7 +32,7 @@ class MeanField:
         self.mean_fields = {}
         for var in self.model.variables:
             self.mean_fields[var] = Factor.initialize_with_(
-                default_message_name(), [var], init_np_func, model.get_cardinality_for_(var)
+                default_message_name(), [var], init_np_func, self.model.get_cardinality_for_(var)
             )
             self.mean_fields[var].normalize()
 

--- a/inferlo/generic/inference/mean_field.py
+++ b/inferlo/generic/inference/mean_field.py
@@ -18,8 +18,8 @@ default_message_name.cnt = 0
 
 
 class MeanField:
-    def __init__(self, model:GraphModel, **kwargs):
-        self.model = GraphicalModel.from_inferlo_model(model).copy()
+    def __init__(self, model: GraphicalModel, **kwargs):
+        self.model = model.copy()
 
         mean_field_init_method = kwargs.get("mean_field_init_method")
         if mean_field_init_method == "random":

--- a/inferlo/generic/inference/mini_bucket_elimination.py
+++ b/inferlo/generic/inference/mini_bucket_elimination.py
@@ -12,9 +12,9 @@ from .graphical_model import GraphicalModel
 
 
 class MiniBucketElimination:
-    def __init__(self, model: GraphModel = None, **kwargs):
+    def __init__(self, model: GraphicalModel = None, **kwargs):
         self.base_logZ = 0.0
-        self.model = GraphicalModel.from_inferlo_model(model).copy()
+        self.model = model.copy()
         if "elimination_order" in kwargs:
             self.elimination_order = copy(kwargs["elimination_order"])
         else:

--- a/inferlo/generic/inference/mini_bucket_elimination.py
+++ b/inferlo/generic/inference/mini_bucket_elimination.py
@@ -2,11 +2,8 @@ import numpy as np
 from copy import copy
 import random
 from functools import reduce
-import sys
 
-sys.path.extend(["graphical_model/"])
-from factor import Factor, product_over_
-from bucket_elimination import BucketElimination
+from .factor import Factor, product_over_
 
 
 class MiniBucketElimination:

--- a/inferlo/generic/inference/mini_bucket_elimination.py
+++ b/inferlo/generic/inference/mini_bucket_elimination.py
@@ -1,0 +1,235 @@
+import numpy as np
+from copy import copy
+import random
+from functools import reduce
+import sys
+
+sys.path.extend(["graphical_model/"])
+from factor import Factor, product_over_
+from bucket_elimination import BucketElimination
+
+
+class MiniBucketElimination:
+    def __init__(self, model=None, **kwargs):
+        self.base_logZ = 0.0
+        self.model = model.copy()
+        if "elimination_order" in kwargs:
+            self.elimination_order = copy(kwargs["elimination_order"])
+        else:
+            self.elimination_order = []
+
+        if "renormalized_model" not in kwargs:
+            self.renormalize_model(**kwargs)
+        else:
+            self.renormalized_model = kwargs["renormalized_model"].copy()
+            self.renormalized_elimination_order = kwargs["renormalized_elimination_order"]
+            self.variables_replicated_from_ = kwargs["variables_replicated_from_"]
+            self.base_logZ = kwargs["base_logZ"]
+
+        self.initialize_relation()
+
+    @classmethod
+    def initialize_with_(cls, mbr):
+        return cls(
+            mbr.model,
+            elimination_order=mbr.elimination_order,
+            renormalized_model=mbr.renormalized_model,
+            renormalized_elimination_order=mbr.renormalized_elimination_order,
+            variables_replicated_from_=mbr.variables_replicated_from_,
+            base_logZ=mbr.base_logZ,
+        )
+
+        return mbr
+
+    def initialize_relation(self):
+        variable_upper_to_ = {var: None for var in self.renormalized_model.variables}
+        variables_lower_to_ = {var: [] for var in self.renormalized_model.variables}
+        factor_upper_to_ = {var: Factor.scalar(1.0) for var in self.renormalized_model.variables}
+        upper_candidate_for_ = {var: set() for var in self.renormalized_model.variables}
+
+        for fac in self.renormalized_model.factors:
+            lower_var = min(fac.variables, key=self.renormalized_elimination_order.index)
+            factor_upper_to_[lower_var] = fac
+            upper_candidate_for_[lower_var] = upper_candidate_for_[lower_var].union(
+                set(fac.variables)
+            )
+
+        for var in self.renormalized_elimination_order:
+            m_vars = sorted(
+                upper_candidate_for_[var], key=self.renormalized_elimination_order.index
+            )
+            upper_candidate_for_[var] = copy(m_vars[m_vars.index(var) + 1 :])
+            if m_vars.index(var) + 1 < len(m_vars):
+                upper_var = m_vars[m_vars.index(var) + 1]
+                variable_upper_to_[var] = upper_var
+                variables_lower_to_[upper_var].append(var)
+                upper_candidate_for_[upper_var] = upper_candidate_for_[upper_var].union(
+                    m_vars[m_vars.index(var) + 1 :]
+                )
+
+        self.variable_upper_to_ = variable_upper_to_
+        self.variables_lower_to_ = variables_lower_to_
+
+        self.factors_adj_to_ = {
+            var: self.renormalized_model.get_adj_factors(var)
+            for var in self.renormalized_model.variables
+        }
+        self.factor_upper_to_ = factor_upper_to_
+        # self.upper_candidate_for_ = upper_candidate_for_
+
+    def renormalize_model(self, **kwargs):
+        ibound = kwargs["ibound"]
+        if "elimination_order_method" in kwargs:
+            if kwargs["elimination_order_method"] == "random":
+                elimination_order = copy(self.model.variables)
+                use_min_fill = False
+                random.shuffle(elimination_order)
+            elif kwargs["elimination_order_method"] == "not_random":
+                elimination_order = copy(self.model.variables)
+                use_min_fill = False
+            elif kwargs["elimination_order_method"] == "min_fill":
+                elimination_order = []
+                use_min_fill = True
+        elif "elimination_order" in kwargs:
+            elimination_order = copy(kwargs["elimination_order"])
+            use_min_fill = False
+        else:
+            elimination_order = copy(self.model.variables)
+            use_min_fill = False
+            random.shuffle(elimination_order)
+            # elimination_order = []
+            # use_min_fill = True
+
+        renormalized_model = self.model.copy()
+        renormalized_elimination_order = []
+
+        variables_replicated_from_ = {var: [] for var in self.model.variables}
+        factors_adj_to_ = dict()
+        working_factorss = [[fac] for fac in renormalized_model.factors]
+        eliminated_variables = []
+        for t in range(len(self.model.variables)):
+            uneliminated_variables = sorted(set(self.model.variables) - set(eliminated_variables))
+            candidate_mini_buckets_for_ = dict()
+
+            bucket_for_ = {cand_var: [] for cand_var in uneliminated_variables}
+            for facs in working_factorss:
+                for cand_var in self.get_variables_in_(
+                    [[fac] for fac in facs], eliminated=eliminated_variables
+                ):
+                    bucket_for_[cand_var].append(facs)
+
+            for cand_var in uneliminated_variables:
+                candidate_mini_buckets_for_[cand_var] = []
+                for facs in bucket_for_[cand_var]:
+                    mini_bucket = next(
+                        (
+                            mb
+                            for mb in candidate_mini_buckets_for_[cand_var]
+                            if self.get_bucket_size(
+                                mb + [facs], eliminated=eliminated_variables + [cand_var]
+                            )
+                            < ibound
+                        ),
+                        False,
+                    )
+                    if mini_bucket:
+                        mini_bucket.append(facs)
+                    else:
+                        candidate_mini_buckets_for_[cand_var].append([facs])
+
+            if use_min_fill:
+                var, mini_buckets = min(
+                    candidate_mini_buckets_for_.items(), key=lambda x: len(x[1])
+                )
+                elimination_order.append(var)
+            else:
+                var = elimination_order[t]
+                mini_buckets = candidate_mini_buckets_for_[var]
+
+            eliminated_variables.append(var)
+            mini_buckets.sort(
+                key=lambda mb: self.get_bucket_size(mb, eliminated=eliminated_variables)
+            )
+
+            remove_idx = []
+            for working_facs_idx, working_facs in enumerate(working_factorss):
+                if var in self.get_variables_in_([[fac] for fac in working_facs]):
+                    remove_idx.append(working_facs_idx)
+
+            for i in reversed(sorted(remove_idx)):
+                working_factorss.pop(i)
+
+            for (i, mb) in enumerate(mini_buckets):
+                mb_facs = [fac for facs in mb for fac in facs]
+                working_factorss.append(mb_facs)
+
+                replicated_var = var + "_" + str(i)
+                variables_replicated_from_[var].append(replicated_var)
+                factors_adj_to_[replicated_var] = [fac for fac in mb_facs if var in fac.variables]
+
+        for var in elimination_order:
+            for replicated_var in variables_replicated_from_[var]:
+                renormalized_model.add_variable(replicated_var)
+                renormalized_elimination_order.append(replicated_var)
+                for fac in factors_adj_to_[replicated_var]:
+                    fac.variables[fac.variables.index(var)] = replicated_var
+
+            renormalized_model.remove_variable(var)
+
+        factors_upper_to_ = {var: [] for var in renormalized_model.variables}
+        for fac in renormalized_model.factors:
+            lower_var = min(fac.variables, key=renormalized_elimination_order.index)
+            factors_upper_to_[lower_var].append(fac)
+
+        for var, facs in factors_upper_to_.items():
+            if facs:
+                new_fac = product_over_(*facs)
+                for fac in facs:
+                    renormalized_model.remove_factor(fac)
+                renormalized_model.add_factor(new_fac)
+
+        base_logZ = 0.0
+        for fac in renormalized_model.factors:
+            base_logZ += np.max(fac.log_values)
+            fac.log_values -= np.max(fac.log_values)
+
+        self.elimination_order = elimination_order
+        self.renormalized_model = renormalized_model
+        self.renormalized_elimination_order = renormalized_elimination_order
+        self.variables_replicated_from_ = variables_replicated_from_
+        self.base_logZ = base_logZ
+
+    def run(self):
+        working_model = self.renormalized_model.copy()
+        for var in self.elimination_order:
+            for i, rvar in enumerate(self.variables_replicated_from_[var]):
+                if i < len(self.variables_replicated_from_[var]) - 1:
+                    working_model.contract_variable(rvar, operator="max")
+                else:
+                    working_model.contract_variable(rvar, operator="sum")
+
+        logZ = self.base_logZ
+        for fac in working_model.factors:
+            logZ += fac.log_values
+
+        return logZ
+
+    def get_variables_in_(self, bucket, eliminated=[]):
+        if [fac.variables for facs in bucket for fac in facs]:
+            variables_in_bucket = reduce(
+                lambda vars1, vars2: set(vars1).union(set(vars2)),
+                [fac.variables for facs in bucket for fac in facs],
+            )
+            variables_in_bucket = sorted(set(variables_in_bucket) - set(eliminated))
+            return list(variables_in_bucket)
+        else:
+            return []
+
+    def get_bucket_size(self, bucket, eliminated=[]):
+        variables_in_bucket = self.get_variables_in_(bucket, eliminated)
+        if variables_in_bucket:
+            return len(
+                variables_in_bucket
+            )  # np.prod([self.model.get_cardinality_for_(var) for var in variables_in_bucket])
+        else:
+            return 0

--- a/inferlo/generic/inference/weighted_mini_bucket_elimination.py
+++ b/inferlo/generic/inference/weighted_mini_bucket_elimination.py
@@ -1,0 +1,219 @@
+import numpy as np
+from copy import copy
+import random
+import time
+import sys
+
+sys.path.extend(["graphical_model/"])
+from graphical_model import GraphicalModel
+from factor import product_over_, Factor
+from mini_bucket_elimination import MiniBucketElimination
+
+
+class WeightedMiniBucketElimination(MiniBucketElimination):
+    def __init__(self, model, **kwargs):
+        super(WeightedMiniBucketElimination, self).__init__(model, **kwargs)
+
+        self.initialize_holder_weights()
+        self.reparameterization_step_size = 0.1
+        self.holder_weight_step_size = 0.1
+        self.messages = dict()
+
+    def initialize_holder_weights(self):
+        holder_weights_for_ = dict()
+        for var, rep_vars in self.variables_replicated_from_.items():
+            for rep_var in rep_vars:
+                holder_weights_for_[rep_var] = 1.0 / len(rep_vars)
+
+        self.holder_weights_for_ = holder_weights_for_
+
+    def run(self, max_iter=10, update_weight=True, update_reparam=True, verbose=False):
+        for var in self.elimination_order:
+            for rvar in self.variables_replicated_from_[var]:
+                self._forward_pass_for_(rvar)
+
+        if max_iter > 0:
+            for var in reversed(self.elimination_order):
+                for rvar in self.variables_replicated_from_[var]:
+                    if self.variable_upper_to_[rvar]:
+                        self._backward_pass_for_(self.variable_upper_to_[rvar], rvar)
+
+        for t in range(max_iter):
+            if verbose:
+                print("{}/{}".format(t, max_iter))
+                print(self.get_logZ())
+            converge_flag = self.update_parameters(
+                update_weight=update_weight, update_reparam=update_reparam
+            )
+            if converge_flag:
+                print(t)
+                break
+
+        for var in self.renormalized_elimination_order:
+            self._forward_pass_for_(var)
+
+        return self.get_logZ()
+
+    def update_parameters(self, update_weight=False, update_reparam=True):
+        converge_flag = False
+        for var in self.elimination_order:
+            # if len(self.variables_replicated_from_[var]) > 1:
+            if update_weight:
+                self._update_holder_weights_for_(var)
+            if update_reparam:
+                reparam_converge_flag = self._update_reparameterization_for_(var)
+                if not reparam_converge_flag:
+                    converge_flag = False
+
+            for rvar in self.variables_replicated_from_[var]:
+                self._forward_pass_for_(rvar)
+
+        for var in reversed(self.elimination_order):
+            # if len(self.variables_replicated_from_[var]) > 1:
+            if update_weight:
+                self._update_holder_weights_for_(var)
+            if update_reparam:
+                reparam_converge_flag = self._update_reparameterization_for_(var)
+                if not reparam_converge_flag:
+                    converge_flag = False
+                    # print(converge_flag)
+
+            for rvar in self.variables_replicated_from_[var]:
+                if self.variable_upper_to_[rvar]:
+                    self._backward_pass_for_(self.variable_upper_to_[rvar], rvar)
+
+        return converge_flag
+
+    def get_logZ(self):
+        logZ = self.base_logZ
+        for var in self.renormalized_elimination_order:
+            if not self.variable_upper_to_[var]:
+                upper_var = self.variable_upper_to_[var]
+                logZ += self.messages[var, upper_var].log_values
+
+        return logZ
+
+    def get_marginals_upper_to_(self, variable):
+        marginal = product_over_(self.factor_upper_to_[variable], *self._messages_to_(variable))
+        marginal.pow(1 / self.holder_weights_for_[variable])
+        marginal.normalize()
+        marginal.name = "q_c_{}".format(variable)
+        return marginal
+
+    def _forward_pass_for_(self, variable):
+        upper_variable = self.variable_upper_to_[variable]
+        message = product_over_(
+            self.factor_upper_to_[variable], *self._upper_messages_to_(variable)
+        )
+        message.marginalize(
+            [variable], operator="weighted_sum", weight=self.holder_weights_for_[variable]
+        )
+        message.name = "M_{}->{}".format(variable, upper_variable)
+
+        self.messages[(variable, upper_variable)] = message
+
+    def _backward_pass_for_(self, variable, lower_variable):
+        message = product_over_(self.factor_upper_to_[variable], *self._messages_to_(variable))
+        message.pow(self.holder_weights_for_[lower_variable] / self.holder_weights_for_[variable])
+        message.div(self.messages[(lower_variable, variable)])
+
+        # variables_in_factor_upper_to_lower_variable = copy(self.factor_upper_to_[lower_variable].variables)
+        # variables_to_marginalize = list(set(message.variables)
+        #                                - set(variables_in_factor_upper_to_lower_variable))
+        # message.marginalize(variables_to_marginalize,
+        #                    operator = 'weighted_sum',
+        #                    weight = self.holder_weights_for_[lower_variable])
+        lower_upper_factor = self.factor_upper_to_[lower_variable]
+        variables_to_marginalize = list(set(message.variables) - set(lower_upper_factor.variables))
+        message.marginalize(
+            variables_to_marginalize,
+            operator="weighted_sum",
+            weight=self.holder_weights_for_[lower_variable],
+        )
+        # variables_not_to_marginalize = self.upper_candidate_for_[lower_variable]
+        # message.marginalize_except_(variables_not_to_marginalize,
+        #                            operator = 'weighted_sum',
+        #                            weight = self.holder_weights_for_[lower_variable])
+        message.name = "M_{}<-{}".format(lower_variable, variable)
+        self.messages[(variable, lower_variable)] = message
+
+    """
+    def _update_reparameterization_for_(self, variable):
+        belief_from_ = dict()
+        average_belief = 0.0
+        for rvar in self.variables_replicated_from_[variable]:
+            belief_from_[rvar] = self.get_marginals_upper_to_(rvar)
+            belief_from_[rvar].marginalize_except_([rvar])
+            belief_from_[rvar].variables = [variable]
+            average_belief = average_belief + belief_from_[rvar].values
+
+        average_belief =  (1.0/len(self.variables_replicated_from_[variable])) * average_belief
+
+        for rvar in self.variables_replicated_from_[variable]:
+            temp_log_val = (- self.reparameterization_step_size / len(self.factors_adj_to_[rvar])) * (belief_from_[rvar].values - average_belief)
+            temp = Factor('', [rvar], log_values = temp_log_val)
+            for fac in self.factors_adj_to_[rvar]:
+                fac.product(temp)
+    """
+
+    def _update_reparameterization_for_(self, variable):
+        belief_from_ = dict()
+        log_average_belief = 0.0
+        average_weight = 0.0
+        for rvar in self.variables_replicated_from_[variable]:
+            belief_from_[rvar] = self.get_marginals_upper_to_(rvar)
+            belief_from_[rvar].marginalize_except_([rvar])
+            belief_from_[rvar].variables = [variable]
+            belief_from_[rvar].normalize()
+            log_average_belief = (
+                log_average_belief + self.holder_weights_for_[rvar] * belief_from_[rvar].log_values
+            )
+
+        converge_flag = True
+        for rvar in self.variables_replicated_from_[variable]:
+            if np.sum(np.abs(-belief_from_[rvar].log_values + log_average_belief)) > 1e-2:
+                converge_flag = False
+                temp_log_val = (self.holder_weights_for_[rvar]) * (
+                    -belief_from_[rvar].log_values + log_average_belief
+                )
+                temp = Factor("", [rvar], log_values=temp_log_val)
+                self.factor_upper_to_[rvar].product(temp)
+
+        return converge_flag
+
+    def _update_holder_weights_for_(self, variable):
+        entropy_for_ = dict()
+        average_entropy = 0.0
+        for rvar in self.variables_replicated_from_[variable]:
+            belief_from_rvar = self.get_marginals_upper_to_(rvar)
+            b_values = belief_from_rvar.values
+            cb_values = belief_from_rvar.normalize([rvar], inplace=False).values
+
+            b_values.ravel()
+            cb_values.ravel()
+            index_to_keep = b_values != 0
+            entropy_for_[rvar] = -np.sum(b_values[index_to_keep] * np.log(cb_values[index_to_keep]))
+
+            average_entropy += self.holder_weights_for_[rvar] * entropy_for_[rvar]
+
+        holder_weight_sum = 0.0
+        for rvar in self.variables_replicated_from_[variable]:
+            self.holder_weights_for_[rvar] *= np.exp(
+                -self.holder_weight_step_size * (entropy_for_[rvar] - average_entropy)
+            )
+            holder_weight_sum += self.holder_weights_for_[rvar]
+
+        for rvar in self.variables_replicated_from_[variable]:
+            self.holder_weights_for_[rvar] /= holder_weight_sum
+
+    def _messages_to_(self, variable):
+        if self.variable_upper_to_[variable]:
+            upper_variable = self.variable_upper_to_[variable]
+            return [self.messages[(upper_variable, variable)]] + self._upper_messages_to_(variable)
+        else:
+            return self._upper_messages_to_(variable)
+
+    def _upper_messages_to_(self, variable):
+        return [
+            self.messages[(lower_var, variable)] for lower_var in self.variables_lower_to_[variable]
+        ]

--- a/inferlo/generic/inference/weighted_mini_bucket_elimination.py
+++ b/inferlo/generic/inference/weighted_mini_bucket_elimination.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
 
-from inferlo.base.graph_model import GraphModel
 from .factor import product_over_, Factor
+from .graphical_model import GraphicalModel
 from .mini_bucket_elimination import MiniBucketElimination
 
 
 class WeightedMiniBucketElimination(MiniBucketElimination):
-    def __init__(self, model: GraphModel, **kwargs):
+    def __init__(self, model: GraphicalModel, **kwargs):
         super(WeightedMiniBucketElimination, self).__init__(model, **kwargs)
 
         self.initialize_holder_weights()

--- a/inferlo/generic/inference/weighted_mini_bucket_elimination.py
+++ b/inferlo/generic/inference/weighted_mini_bucket_elimination.py
@@ -1,10 +1,14 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
-from inferlo.generic.inference.factor import product_over_, Factor
+
+from inferlo.base.graph_model import GraphModel
+from .factor import product_over_, Factor
 from .mini_bucket_elimination import MiniBucketElimination
 
 
 class WeightedMiniBucketElimination(MiniBucketElimination):
-    def __init__(self, model, **kwargs):
+    def __init__(self, model: GraphModel, **kwargs):
         super(WeightedMiniBucketElimination, self).__init__(model, **kwargs)
 
         self.initialize_holder_weights()
@@ -208,7 +212,7 @@ class WeightedMiniBucketElimination(MiniBucketElimination):
         for rvar in self.variables_replicated_from_[variable]:
             self.holder_weights_for_[rvar] *= np.exp(
                 -self.holder_weight_step_size * (
-                            entropy_for_[rvar] - average_entropy)
+                        entropy_for_[rvar] - average_entropy)
             )
             holder_weight_sum += self.holder_weights_for_[rvar]
 

--- a/inferlo/pairwise/junction_tree.py
+++ b/inferlo/pairwise/junction_tree.py
@@ -31,7 +31,7 @@ def build_multi_delta(var_num, al_size, nodes1, nodes2):
     :return: Square boolean matrix of size al_size ** var_num.
     """
     ans_size = al_size ** var_num
-    ans = np.ones((ans_size, ans_size), dtype=np.bool)
+    ans = np.ones((ans_size, ans_size), dtype=bool)
     for i in range(len(nodes1)):
         for j in range(len(nodes2)):
             if nodes1[i] != nodes2[j]:

--- a/inferlo/pairwise/optimization/convex_bounds.py
+++ b/inferlo/pairwise/optimization/convex_bounds.py
@@ -23,25 +23,30 @@ def lp_relaxation(model: PairWiseFiniteModel) -> LPRelaxResult:
     :param model: Model for which to find most likely state.
     :return: Solution of LP relaxation of the Max Likelihood problem.
 
-    1) Reformulates the original problem of maximizing
-            sum F[i][X_i] + 0.5*sum J[i][j][X[i]][X[j]])
-    as a binary optimization problem by introducing new variables
-    y_i,a and z_i,j,a,b:
-        maximize (sum_i sum_a F[i][a] * y_i,a) +
-                 (sum_i sum_j sum_a sum_b 0.5*sum J[i][j][a][b] * z_i,j,a,b))
-        subject to y_i,a in {0, 1}
-                z_i,j,a,b in {0, 1}
-                (for all i) sum_a y_i,a = 1
-                z_i,j,a,b <= y_i,a
-                z_i,j,a,b <= y_j,b
-                z_i,j,a,b >= y_i,a + y_j,b - 1
+    1. Reformulates the original problem of maximizing
+       ``sum F[i][X_i] + 0.5*sum J[i][j][X[i]][X[j]])``
+       as a binary optimization problem by introducing new variables
+       ``y_i,a`` and ``z_i,j,a,b``:
 
-    2) Solves the LP relaxation by relaxing binary constraints to
-                y_i,a in [0, 1]
-                z_i,j,a,b in [0, 1]
+       maximize ``(sum_i sum_a F[i][a] * y_i,a) +
+       (sum_i sum_j sum_a sum_b 0.5*sum J[i][j][a][b] * z_i,j,a,b))``
 
-    Note that z will be reshaped to matrix.
-    (cvxpy do not support tensor variables)
+       subject to
+
+       * ``y_i,a in {0, 1}``
+       * ``z_i,j,a,b in {0, 1}``
+       * ``(for all i) sum_a y_i,a = 1``
+       * ``z_i,j,a,b <= y_i,a``
+       * ``z_i,j,a,b <= y_j,b``
+       * ``z_i,j,a,b >= y_i,a + y_j,b - 1``
+
+    2. Solves the LP relaxation by relaxing binary constraints to
+
+       * ``y_i,a in [0, 1]``
+       * ``z_i,j,a,b in [0, 1]``
+
+    Note that ``z`` will be reshaped to matrix.
+    (cvxpy does not support tensor variables)
     """
     edge_list = model.edges
 

--- a/inferlo/pairwise/optimization/convex_hierarchies.py
+++ b/inferlo/pairwise/optimization/convex_hierarchies.py
@@ -43,7 +43,7 @@ def sherali_adams(model: PairWiseFiniteModel, level=3) -> sherali_adams_result:
     # introduce cluster variables and constraints
     clusters = {}
     constraints = []
-    for cluster_size in range(1, level+1):
+    for cluster_size in range(1, level + 1):
         variables = list(combinations(range(var_size), cluster_size))
         values = list(product(range(al_size), repeat=cluster_size))
 
@@ -59,7 +59,7 @@ def sherali_adams(model: PairWiseFiniteModel, level=3) -> sherali_adams_result:
             # add marginalization constraints
             for cluster_subset_size in range(1, cluster_size):
                 all_cluster_subsets = list(combinations(
-                    list(cluster_ids),  cluster_subset_size))
+                    list(cluster_ids), cluster_subset_size))
                 subset_values = list(product(
                     range(al_size), repeat=cluster_subset_size))
 
@@ -69,9 +69,9 @@ def sherali_adams(model: PairWiseFiniteModel, level=3) -> sherali_adams_result:
                         marginal_sum = 0.0
                         for value, cp_variable in cluster.items():
                             consistency = [value[
-                                               cluster_ids.index(subset_ids[i])
-                                           ] == subset_x[i]
-                                           for i in range(cluster_subset_size)]
+                                cluster_ids.index(subset_ids[i])
+                            ] == subset_x[i]
+                                for i in range(cluster_subset_size)]
                             if sum(consistency) == len(subset):
                                 marginal_sum += cp_variable
 
@@ -85,7 +85,7 @@ def sherali_adams(model: PairWiseFiniteModel, level=3) -> sherali_adams_result:
     for node in range(var_size):
         for letter in range(al_size):
             objective += model.field[node, letter] * \
-                         clusters[(node,)][(letter,)]
+                clusters[(node,)][(letter,)]
 
     # add pairwise interactions
     # a and b iterate over all values of the finite field
@@ -164,7 +164,7 @@ def minimal_cycle(model: PairWiseFiniteModel) -> sherali_adams_result:
             # add marginalization constraints
             for cluster_subset_size in range(1, cluster_size):
                 all_cluster_subsets = list(combinations(
-                    list(cluster_ids),  cluster_subset_size))
+                    list(cluster_ids), cluster_subset_size))
                 subset_values = list(product(
                     range(al_size), repeat=cluster_subset_size))
 
@@ -174,9 +174,9 @@ def minimal_cycle(model: PairWiseFiniteModel) -> sherali_adams_result:
                         marginal_sum = 0.0
                         for value, cp_variable in cluster.items():
                             consistency = [value[
-                                               cluster_ids.index(subset_ids[i])
-                                           ] == subset_x[i]
-                                           for i in range(cluster_subset_size)]
+                                cluster_ids.index(subset_ids[i])
+                            ] == subset_x[i]
+                                for i in range(cluster_subset_size)]
                             if sum(consistency) == len(subset):
                                 marginal_sum += cp_variable
 
@@ -190,9 +190,8 @@ def minimal_cycle(model: PairWiseFiniteModel) -> sherali_adams_result:
     for cycle in cycles:
         cycle.append(cycle[0])
         cycle_edges = []
-        for i in range(len(cycle)-1):
-            edge = [cycle[i], cycle[i+1]]
-            edge.sort()
+        for i in range(len(cycle) - 1):
+            edge = sorted([cycle[i], cycle[i + 1]])
             cycle_edges.append(tuple(edge))
 
         cycle_values = list(product(range(al_size), repeat=len(cycle)))
@@ -226,7 +225,7 @@ def minimal_cycle(model: PairWiseFiniteModel) -> sherali_adams_result:
     for node in range(var_size):
         for letter in range(al_size):
             objective += model.field[node, letter] * \
-                         clusters[(node,)][(letter,)]
+                clusters[(node,)][(letter,)]
 
     # add pairwise interactions
     # a and b iterate over all values of the finite field
@@ -278,7 +277,7 @@ class Indexing:
     first_index = [0, 1]
 
     def __init__(self, n, q, level=1):
-        for current_level in range(1, level+1):
+        for current_level in range(1, level + 1):
             clusters = list(combinations(range(n), current_level))
             values = list(product(range(q), repeat=current_level))
             self.values[current_level] = values
@@ -335,8 +334,7 @@ def union(cluster_a, value_a, cluster_b, value_b):
     cluster_b_list = list(cluster_b)
     value_b_list = list(value_b)
     value_ab = []
-    cluster_ab = list(set(cluster_a_list + cluster_b_list))
-    cluster_ab.sort()
+    cluster_ab = sorted(set(cluster_a_list + cluster_b_list))
     for i in range(len(cluster_ab)):
         if cluster_ab[i] in cluster_a_list:
             index = cluster_a_list.index(cluster_ab[i])
@@ -401,7 +399,7 @@ def lasserre(model: PairWiseFiniteModel, level=1) -> lasserre_result:
         for value_a in clusters[cluster_a].keys():
             a = ind.find(cluster_a, value_a)
             a_variable = clusters[cluster_a][value_a]
-            constraints += [moment_matrix[0,  a['index']] == a_variable]
+            constraints += [moment_matrix[0, a['index']] == a_variable]
 
             for cluster_b in clusters_list:
                 for value_b in clusters[cluster_b].keys():
@@ -409,8 +407,8 @@ def lasserre(model: PairWiseFiniteModel, level=1) -> lasserre_result:
 
                     if (cluster_a == cluster_b) and (value_a == value_b):
                         constraints += [moment_matrix[
-                                            a['index'],  b['index']
-                                        ] == a_variable]
+                            a['index'], b['index']
+                        ] == a_variable]
                     elif (cluster_a != cluster_b) and \
                             (compatible(cluster_a, value_a,
                                         cluster_b, value_b)):
@@ -419,8 +417,8 @@ def lasserre(model: PairWiseFiniteModel, level=1) -> lasserre_result:
                         if cluster_ab in clusters.keys():
                             variable_ab = clusters[cluster_ab][value_ab]
                             constraints += [moment_matrix[
-                                                a['index'], b['index']
-                                            ] == variable_ab]
+                                a['index'], b['index']
+                            ] == variable_ab]
 
     objective = 0.0
 
@@ -428,7 +426,7 @@ def lasserre(model: PairWiseFiniteModel, level=1) -> lasserre_result:
     for node in range(var_size):
         for letter in range(al_size):
             objective += model.field[node, letter] * \
-                        clusters[(node,)][(letter,)]
+                clusters[(node,)][(letter,)]
 
     # add pairwise interactions
     # a and b iterate over all values of the finite field

--- a/inferlo/pairwise/optimization/convex_hierarchies.py
+++ b/inferlo/pairwise/optimization/convex_hierarchies.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from collections import namedtuple
 from itertools import product, combinations
 import cvxpy as cp

--- a/inferlo/pairwise/optimization/convex_hierarchies_test.py
+++ b/inferlo/pairwise/optimization/convex_hierarchies_test.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import sys
 import pytest
 

--- a/inferlo/pairwise/optimization/map_lp.py
+++ b/inferlo/pairwise/optimization/map_lp.py
@@ -86,8 +86,8 @@ def map_lp(model: PairWiseFiniteModel) -> map_lp_result:
     # normalization constraints
     for edge in edge_list:
         constraints += [sum([edge_beliefs[edge_list.index(edge)][a, b]
-                        for a in range(model.al_size)
-                        for b in range(model.al_size)]) == 1]
+                             for a in range(model.al_size)
+                             for b in range(model.al_size)]) == 1]
 
     # marginalization constraints
     for edge in edge_list:

--- a/inferlo/pairwise/optimization/map_lp.py
+++ b/inferlo/pairwise/optimization/map_lp.py
@@ -13,49 +13,51 @@ map_lp_result = namedtuple('map_lp_result', ['upper_bound',
 
 
 def map_lp(model: PairWiseFiniteModel) -> map_lp_result:
-    """
-        This function implements linear programming (LP) relaxation
-        of maximum a posteriori assignment problem (MAP) for
-        pairwise graphical model with finite alphabet.
+    """LP relaxation of MAP problem for pairwise model.
 
-        The goal of MAP estimation is to find most probable
-        assignment of original variables by maximizing probability
-        density function. For the case of pairwise finite model it
-        reduces to maximization of quadratic function over finite
-        field.
+    This function implements linear programming (LP) relaxation
+    of maximum a posteriori assignment problem (MAP) for
+    pairwise graphical model with finite alphabet.
 
-        For every node, we introduce Q non-negative belief variables
-        where Q is the size of the alphabet. Every such variable
-        is our 'belief' that variable at node takes particular value.
+    The goal of MAP estimation is to find most probable
+    assignment of original variables by maximizing probability
+    density function. For the case of pairwise finite model it
+    reduces to maximization of quadratic function over finite
+    field.
 
-        Analogously, for every edge we introduce Q*Q pairwise beliefs.
+    For every node, we introduce Q non-negative belief variables
+    where Q is the size of the alphabet. Every such variable
+    is our 'belief' that variable at node takes particular value.
 
-        For both node and edge beliefs we require normalization
-        constraints: 1) for every node, the sum of beliefs equals one
-        and 2) for every edge the sum of edge-beliefs equals one.
+    Analogously, for every edge we introduce Q*Q pairwise beliefs.
 
-        We also add marginalization constraint: for every edge,
-        summing edge beliefs over one of the nodes must equal
-        to the node belief of the second node.
+    For both node and edge beliefs we require normalization
+    constraints: 1) for every node, the sum of beliefs equals one
+    and 2) for every edge the sum of edge-beliefs equals one.
 
-        Finally we get a linear program and its solution is an
-        upper bound on the MAP value. We restore the lower bound
-        on MAP value as the solution of the dual relaxation.
+    We also add marginalization constraint: for every edge,
+    summing edge beliefs over one of the nodes must equal
+    to the node belief of the second node.
 
-        More details may be found in "MAP Estimation,
-        Linear Programming and BeliefPropagation with
-        Convex Free Energies" by Yair Weiss, Chen Yanover and Talya
-        Meltzer. https://arxiv.org/pdf/1206.5286.pdf
+    Finally we get a linear program and its solution is an
+    upper bound on the MAP value. We restore the lower bound
+    on MAP value as the solution of the dual relaxation.
 
-        The output of the function is:
-        1) upper bound on MAP value (solution of LP)
-        2) lower bound on MAP value (dual solution)
-        3) Optimal values of node beliefs
-        4) Optimal values of edge beliefs
-        5) Optimal values of dual variables that correspond to
-          normalization constraints
-        6) Optimal values of dual variables that correspond to
-          marginalization constraints
+    More details may be found in "MAP Estimation,
+    Linear Programming and BeliefPropagation with
+    Convex Free Energies" by Yair Weiss, Chen Yanover and Talya
+    Meltzer. https://arxiv.org/pdf/1206.5286.pdf
+
+    The output of the function is:
+
+    1. upper bound on MAP value (solution of LP);
+    2. lower bound on MAP value (dual solution);
+    3. Optimal values of node beliefs;
+    4. Optimal values of edge beliefs;
+    5. Optimal values of dual variables that correspond to normalization
+       constraints;
+    6. Optimal values of dual variables that correspond to marginalization
+       constraints.
     """
 
     edge_list = model.edges

--- a/inferlo/pairwise/optimization/map_lp.py
+++ b/inferlo/pairwise/optimization/map_lp.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 from collections import namedtuple
 import cvxpy as cp
 

--- a/inferlo/pairwise/optimization/map_lp_test.py
+++ b/inferlo/pairwise/optimization/map_lp_test.py
@@ -1,3 +1,5 @@
+# Copyright (c) The InferLO authors. All rights reserved.
+# Licensed under the Apache License, Version 2.0 - see LICENSE.
 import numpy as np
 
 from inferlo import PairWiseFiniteModel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-cvxpy>=1.1.1,!=1.1.8
+cvxpy>=1.1.1
 networkx>=2.4
 numba>=0.51
-numpy>=1.17
+numpy>=1.18
 scipy>=1.4
 scikit-learn>=0.18
 wget>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17
-cvxpy>=1.1.1
+cvxpy>=1.1.2
 networkx>=2.4
 numba>=0.51
 scipy>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17
-cvxpy>=1.1.2
+cvxpy>=1.1.1,!=1.18
 networkx>=2.4
 numba>=0.51
 scipy>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.17
-cvxpy>=1.1.1,!=1.18
+cvxpy>=1.1.1,!=1.1.8
 networkx>=2.4
 numba>=0.51
 scipy>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-cvxpy>=1.1.1
+cvxpy>=1.1.1,!=1.1.8
 networkx>=2.4
-numba>=0.51
-numpy>=1.14
-scipy>=1.4
+numba>=0.52.0
+numpy>=1.17
 scikit-learn>=0.18
+scipy>=1.4
 wget>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-cvxpy>=1.1.1
-llvmlite>=0.33.0dev0,<0.34 # Temporary match numba's requrement.
-networkx>=2.4
-numba>=0.50.1, <0.51
 numpy>=1.17
+cvxpy>=1.1.1
+networkx>=2.4
+numba>=0.51
 scipy>=1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+numpy>=1.17
 cvxpy>=1.1.1,!=1.1.8
 networkx>=2.4
 numba>=0.52.0
-numpy>=1.17
 scikit-learn>=0.18
 scipy>=1.4
 wget>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-numpy>=1.17
 cvxpy>=1.1.1,!=1.1.8
 networkx>=2.4
 numba>=0.51
+numpy>=1.17
 scipy>=1.4
+scikit-learn>=0.18
+wget>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy>=1.17
 cvxpy>=1.1.1,!=1.1.8
 networkx>=2.4
 numba>=0.52.0
+numpy>=1.17
 scikit-learn>=0.18
 scipy>=1.4
 wget>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cvxpy>=1.1.1
 networkx>=2.4
 numba>=0.51
-numpy>=1.18
+numpy>=1.14
 scipy>=1.4
 scikit-learn>=0.18
 wget>=3.0

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -1,1 +1,1 @@
-pycodestyle inferlo && pylint --rcfile=tools/pylintrc.txt inferlo
+pycodestyle --max-line-length=80 inferlo && pylint --rcfile=tools/pylintrc.txt inferlo

--- a/tools/license.py
+++ b/tools/license.py
@@ -1,11 +1,12 @@
 import os
 
-license_notice = \
-    """# Copyright (c) 2020, The InferLO authors. All rights reserved.
-# Licensed under the Apache License, Version 2.0 - see LICENSE file.
-"""
+LICENSE_NOTICE = ''.join([
+    '# Copyright (c) The InferLO authors. All rights reserved.\n'
+    '# Licensed under the Apache License, Version 2.0 - see LICENSE.\n'
+])
 
-license_name = 'Apache License'
+LICENSE_NAME = 'Apache License'
+assert LICENSE_NAME in LICENSE_NOTICE
 
 
 def needs_license(file_name):
@@ -15,14 +16,14 @@ def needs_license(file_name):
         return False
     with open(file_name, encoding='utf-8') as f:
         content = f.read()
-    return not license_name in content
+    return not LICENSE_NAME in content
 
 
 def append_license(file_name):
     with open(file_name, 'r', encoding='utf-8') as f:
         content = ''.join(f.readlines())
     with open(file_name, 'w', encoding='utf-8') as f:
-        f.write(license_notice + content)
+        f.write(LICENSE_NOTICE + content)
 
 
 if __name__ == "__main__":
@@ -35,3 +36,4 @@ if __name__ == "__main__":
                 files_need_license.append(file_name)
     for file_name in files_need_license:
         append_license(file_name)
+        print("Appended license to %s" % file_name)


### PR DESCRIPTION
This pull request checks in algorithms from [this repository](https://github.com/sungsoo-ahn/bucket-renormalization).
In particular, it adds Bucket Renormalization algorithm described in [this paper](https://arxiv.org/abs/1803.05104).

These algorithms use their own object model (i.e. classes for GraphicalModel and Factor). Temporarily we will convert from InferLO's object model to these classes - but eventually we will directly use InferLO classes in new algorithms.

Also:
* Changed new code to conform to style guide.
* Added helpers to load UAI datasets.
* Fixed documentation.
* Updated dependencies (increased Numba dependency to 52.0, forbade CVXPY 1.1.8, added wget>=3.0 and sklearn>=0.18).
* Removed MacOS tests. There is a problem with installing SCS on MacOS, see [this issue](https://github.com/cvxgrp/scs/issues/130).