### PR TITLE
Backwards Bucket Elimination algorithm

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -60,6 +60,7 @@ Inference algorithms
     inferlo.generic.libdai_bp.BP
     inferlo.generic.message_passing.infer_generic_message_passing
     inferlo.generic.inference.inference
+    inferlo.generic.inference.BackwardBucketElimination
     inferlo.gaussian.inference.gaussian_belief_propagation.gaussian_BP
     inferlo.pairwise.bruteforce.infer_bruteforce
     inferlo.pairwise.junction_tree.infer_junction_tree

--- a/inferlo/generic/inference/__init__.py
+++ b/inferlo/generic/inference/__init__.py
@@ -9,6 +9,7 @@ from .inference import (belief_propagation,
                         mini_bucket_elimination_bt,
                         mini_bucket_renormalization_bt,
                         weighted_mini_bucket_elimination)
+from .backward_bucket_elimination import BackwardBucketElimination
 
 """
 Some code in this directory was copied from

--- a/inferlo/generic/inference/backward_bucket_elimination.py
+++ b/inferlo/generic/inference/backward_bucket_elimination.py
@@ -1,0 +1,86 @@
+from scipy.special import softmax
+
+from inferlo import GenericGraphModel, InferenceResult
+from inferlo.generic.inference.factor import product_over_
+from inferlo.generic.inference.inference import _convert
+from inferlo.base.inference_result import marg_probs_to_array
+
+
+class BackwardBucketElimination:
+    """Backwards Bucket Elimination algorithm.
+
+    This is regular Bucket Elimination algorithm followed by a "backward" for computing marginal
+    probabilities.
+
+    Implemented as described in [1] (pages 31-32), code uses notation from [1].
+
+    References
+        [1] Qiang Liu.
+        Reasoning and Decisions in Probabilistic Graphical Models – A Unified Framework. 2014.
+        http://sli.ics.uci.edu/pmwiki/uploads/Group/liu_phd.pdf
+    """
+
+    @staticmethod
+    def infer( model: GenericGraphModel) -> InferenceResult:
+        """Performs inference for graphical model."""
+        model = _convert(model)
+        elimination_order = model.variables
+        buckets = dict()
+        new_factors = dict()
+        marg_prob = dict()  # Factors - marg prob for bucket corresponding to variable.
+        i_to_j = dict()  # var_id -> j (id to whose bucket received new factor for var_id).
+        c = dict()
+
+        for var_id in elimination_order:
+            # Find the bucket, and store it.
+            bucket = model.get_adj_factors(var_id)
+            # Eliminate the variable.
+            new_factor = product_over_(*bucket)
+            new_factor.marginalize(variables=[var_id])
+            new_factor.name = 'new_' + var_id
+            # Update the factor list.
+            model.remove_factors_from(bucket)
+            model.add_factor(new_factor)
+            # Store.
+            buckets[var_id] = bucket
+            new_factors[var_id] = new_factor
+            for factor in bucket:
+                if factor.name.startswith('new_'):
+                    i_to_j[factor.name[4:]] = var_id
+            # c_i - set of variables on which bucket depends.
+            pi_i = set(new_factors[var_id].variables)
+            c[var_id] = pi_i.union({var_id})
+
+        # Backward pass.
+        # Find marginals for the last variable.
+        last_var = elimination_order[-1]
+        marg_prob[last_var] = product_over_(*buckets[last_var])
+
+        for var_id in elimination_order[::-1][1:]:
+            # Find conditional probability.
+            p = product_over_(*buckets[var_id]) / new_factors[var_id]
+            # Multiply by marg.prob for variable whose bucket received new factor for var_id.
+            j = i_to_j[var_id]
+            p = p * marg_prob[j]
+            # Marginalize by extra variables.
+            to_marg = list((c[j] - c[var_id]).intersection(set(p.variables)))
+            if len(to_marg) > 0:
+                p.marginalize(variables=to_marg)
+            assert (set(p.variables) == c[var_id])
+            # Store the result
+            marg_prob[var_id] = p
+
+        # Process results - reduce to 1-variable marginals and convert to probabilties.
+        ans_mp = []
+        for var_id in model.variables:
+            p = marg_prob[var_id]
+            p.marginalize_except_([var_id])
+            p = softmax(p.log_values)
+            assert len(p.shape) == 1
+            ans_mp.append(p)
+
+        log_pf = product_over_(*model.factors).log_values.item()
+        return InferenceResult(
+            log_pf=log_pf,
+            marg_prob=marg_probs_to_array(ans_mp)
+        )

--- a/inferlo/generic/inference/backward_bucket_elimination.py
+++ b/inferlo/generic/inference/backward_bucket_elimination.py
@@ -7,10 +7,10 @@ from inferlo.base.inference_result import marg_probs_to_array
 
 
 class BackwardBucketElimination:
-    """Backwards Bucket Elimination algorithm.
+    """Backward Bucket Elimination algorithm.
 
-    This is regular Bucket Elimination algorithm followed by a "backward" for computing marginal
-    probabilities.
+    This is the regular Bucket Elimination algorithm followed by a "backward pass" for computing
+    marginal probabilities.
 
     Implemented as described in [1] (pages 31-32), code uses notation from [1].
 
@@ -21,7 +21,7 @@ class BackwardBucketElimination:
     """
 
     @staticmethod
-    def infer( model: GenericGraphModel) -> InferenceResult:
+    def infer(model: GenericGraphModel) -> InferenceResult:
         """Performs inference for graphical model."""
         model = _convert(model)
         elimination_order = model.variables
@@ -29,7 +29,7 @@ class BackwardBucketElimination:
         new_factors = dict()
         marg_prob = dict()  # Factors - marg prob for bucket corresponding to variable.
         i_to_j = dict()  # var_id -> j (id to whose bucket received new factor for var_id).
-        c = dict()
+        c = dict()  # For every bucket - set of variables on which it depends.
 
         for var_id in elimination_order:
             # Find the bucket, and store it.

--- a/inferlo/generic/inference/backward_bucket_elimination_test.py
+++ b/inferlo/generic/inference/backward_bucket_elimination_test.py
@@ -1,0 +1,11 @@
+import inferlo
+from inferlo.generic.inference import BackwardBucketElimination
+from inferlo.testing import assert_results_close, grid_potts_model
+
+
+def test_potts_grid():
+    model = grid_potts_model(6, 5, al_size=3)
+    true_result = model.infer(algo='parth_dp')
+    model = inferlo.GenericGraphModel.from_model(model)
+    bw_result = BackwardBucketElimination.infer(model)
+    assert_results_close(true_result, bw_result)

--- a/inferlo/generic/inference/factor.py
+++ b/inferlo/generic/inference/factor.py
@@ -368,6 +368,9 @@ class Factor:
         else:
             return self.product(1 / other, inplace=False)
 
+    def __truediv__(self, other):
+        return self.__div__(other)
+
     def __rmul__(self, other):
         return self.__mul__(other)
 


### PR DESCRIPTION
This is modification of Bucket Elimination which allows to efficiently compute marginal probabilities.

Implemented as described in Algorithm 3.2 here: http://sli.ics.uci.edu/pmwiki/uploads/Group/liu_phd.pdf